### PR TITLE
Added actionCreatorsExtractor coverage for action types declared as variables or obj properties

### DIFF
--- a/lib/seedux/src/seeduxExtractor.js
+++ b/lib/seedux/src/seeduxExtractor.js
@@ -115,14 +115,36 @@ return headNode;
 
 const actionCreatorsExtractor = (actionCreators) => {
   const headNode = new Node('Action Creators');
+    headNode.children = [];
   const actionCreatorNames = Object.keys(actionCreators);
   const strActionCreators = JSON.stringify(actionCreators);
-  const actionTypes = strActionCreators.split('type:').map(t => t.match(/['"]\w*['",]/gi), '').slice(1);
-  headNode.children = [];
+  let actionTypes;
 
-  for (let i = 0; i < actionTypes.length; i++) {
-    if (actionTypes[i] !== null) {
-      actionTypes[i] = actionTypes[i][0].replace(/['"\\]/g, '');
+  // Parses action types declared as variables
+
+  if (/type:\s\w*\,/.test(strActionCreators)) {
+    actionTypes = strActionCreators.split('type:').slice(1).map(subStr => subStr = subStr.slice(1, subStr.indexOf(','))).map(subStr => subStr.includes('\\') ? subStr = subStr.slice(0, subStr.indexOf('\\')) : subStr = subStr);
+  }
+
+  // Parses action types that are properties on an object
+
+  else if (/types*\.\w*/.test(strActionCreators)) {
+    const types = strActionCreators.includes('types.');
+    if (types) {
+      actionTypes = strActionCreators.split('types.').slice(1).map(subStr => subStr = subStr.slice(0, subStr.indexOf(','))).map(subStr => subStr.includes('\\') ? subStr = subStr.slice(0, subStr.indexOf('\\')) : subStr = subStr)
+    }
+    else { actionTypes = strActionCreators.split('type.').slice(1).map(subStr => subStr = subStr.slice(0, subStr.indexOf(','))).map(subStr => subStr.includes('\\') ? subStr = subStr.slice(0, subStr.indexOf('\\')) : subStr = subStr) }
+  }
+  
+  // Parses action types that are strings
+
+  else if (/type:\s['"]\w*['"]\,/) {
+    actionTypes = strActionCreators.split('type:').map(t => t.match(/['"]\w*['",]/gi), '').slice(1);
+
+    for (let i = 0; i < actionTypes.length; i++) {
+      if (actionTypes[i] !== null) {
+        actionTypes[i] = actionTypes[i][0].replace(/['"\\]/g, '');
+      }
     }
   }
 

--- a/test/fixtures/seeduxActionExtractorFixtures.js
+++ b/test/fixtures/seeduxActionExtractorFixtures.js
@@ -1,4 +1,4 @@
-// Todo: Enable handling of actionCreators returning multiple payloads with different types
+// Action type constants as strings for testUI1
 
 const addTodo = (text) => {
   return {
@@ -34,6 +34,92 @@ const redoAction = () => {
   }
 }
 
+// Action type constants declared as variables for testUI2
+
+const ADD_TODO = 'ADD_TODO';
+const SET_VISIBILITY_FILTER = 'SET_VISIBILITY_FILTER';
+const TOGGLE_TODO = 'TOGGLE_TODO';
+const UNDO = 'UNDO';
+const REDO = 'REDO';
+
+const addTodo2 = (text) => {
+  return {
+    type: ADD_TODO,
+    id: nextTodoId++,
+    text
+  }
+}
+
+const setVisibilityFilter2 = (filter) => {
+  return {
+    type: SET_VISIBILITY_FILTER,
+    filter
+  }
+}
+
+const toggleTodo2 = (id) => {
+  return {
+    type: TOGGLE_TODO,
+    id
+  }
+}
+
+const undoAction2 = () => {
+  return {
+    type: UNDO
+  }
+}
+
+const redoAction2 = () => {
+  return {
+    type: REDO
+  }
+}
+
+// Action type constancts as object properties for testUI3
+
+const types = {
+  ADD_TODO: 'ADD_TODO',
+  SET_VISIBILITY_FILTER: 'SET_VISIBILITY_FILTER',
+  TOGGLE_TODO: 'TOGGLE_TODO',
+  UNDO: 'UNDO',
+  REDO: 'REDO'
+}
+
+const addTodo3 = (text) => {
+  return {
+    type: types.ADD_TODO,
+    id: nextTodoId++,
+    text
+  }
+}
+
+const setVisibilityFilter3 = (filter) => {
+  return {
+    type: types.SET_VISIBILITY_FILTER,
+    filter
+  }
+}
+
+const toggleTodo3 = (id) => {
+  return {
+    type: types.TOGGLE_TODO,
+    id
+  }
+}
+
+const undoAction3 = () => {
+  return {
+    type: types.UNDO
+  }
+}
+
+const redoAction3 = () => {
+  return {
+    type: types.REDO
+  }
+}
+
 // Simulates code injected into Redux's native bindActionCreators function
 
 function seeduxbindActionCreatorsLogic(actionCreators, dispatch) {
@@ -46,6 +132,8 @@ function seeduxbindActionCreatorsLogic(actionCreators, dispatch) {
 }
 
 const testActionCreators = seeduxbindActionCreatorsLogic({addTodo, setVisibilityFilter, toggleTodo, undoAction, redoAction});
+const testActionCreators2 = seeduxbindActionCreatorsLogic({addTodo2, setVisibilityFilter2, toggleTodo2, undoAction2, redoAction2});
+const testActionCreators3 = seeduxbindActionCreatorsLogic({addTodo3, setVisibilityFilter3, toggleTodo3, undoAction3, redoAction3});
 
 const answerActionCreators = {
   'name': 'Action Creators',
@@ -93,4 +181,96 @@ const answerActionCreators = {
   ]
 }
 
-module.exports = { testActionCreators, answerActionCreators };
+const answerActionCreators2 = {
+  'name': 'Action Creators',
+  'children': [
+    {
+      'name': 'addTodo2',
+      'children': [
+        {
+          'name': 'ADD_TODO'
+        }
+      ]
+    },
+    {
+      'name': 'setVisibilityFilter2',
+      'children': [
+        {
+          'name': 'SET_VISIBILITY_FILTER'
+        }
+      ]
+    },
+    {
+      'name': 'toggleTodo2',
+      'children': [
+        {
+          'name': 'TOGGLE_TODO'
+        }
+      ]
+    },
+    {
+      'name': 'undoAction2',
+      'children': [
+        {
+          'name': 'UNDO'
+        }
+      ]
+    },
+    {
+      'name': 'redoAction2',
+      'children': [
+        {
+          'name': 'REDO'
+        }
+      ]
+    }
+  ]
+}
+
+const answerActionCreators3 = {
+  'name': 'Action Creators',
+  'children': [
+    {
+      'name': 'addTodo3',
+      'children': [
+        {
+          'name': 'ADD_TODO'
+        }
+      ]
+    },
+    {
+      'name': 'setVisibilityFilter3',
+      'children': [
+        {
+          'name': 'SET_VISIBILITY_FILTER'
+        }
+      ]
+    },
+    {
+      'name': 'toggleTodo3',
+      'children': [
+        {
+          'name': 'TOGGLE_TODO'
+        }
+      ]
+    },
+    {
+      'name': 'undoAction3',
+      'children': [
+        {
+          'name': 'UNDO'
+        }
+      ]
+    },
+    {
+      'name': 'redoAction3',
+      'children': [
+        {
+          'name': 'REDO'
+        }
+      ]
+    }
+  ]
+}
+
+module.exports = { testActionCreators, testActionCreators2, testActionCreators3, answerActionCreators, answerActionCreators2, answerActionCreators3 };

--- a/test/fixtures/seeduxAngularExtractorFixtures.js
+++ b/test/fixtures/seeduxAngularExtractorFixtures.js
@@ -1,0 +1,39 @@
+// class CounterController {
+
+//   constructor($ngRedux, $scope) {
+//     const unsubscribe = $ngRedux.connect(this.mapStateToThis, CounterActions)(this);
+//     $scope.$on('$destroy', unsubscribe);
+//   }
+
+//   // Which part of the Redux global state does our component want to receive?
+//   mapStateToThis(state) {
+//     return {
+//       value: state.counter
+//     };
+//   }
+// }
+
+
+// class TestClass {
+//   constructor() {
+//     this.words = seeduxNGReduxConnectorLogic(this.mapStateToTarget, this);
+//   }
+//   mapStateToTarget() {
+//     console.log(this); 
+//   }
+// }
+
+// const test = new TestClass();
+
+// function seeduxNGReduxConnectorLogic(mapStateToTarget, prototype) {
+  // console.log(prototype)
+  // const controller = Object.getOwnPropertyDescriptor(mapStateToTarget);
+  // const coerceToString = '';
+  // const mappedState = mapStateToTarget + coerceToString;
+  // console.log({[controller]: mappedState})
+  // return { [controller]: mappedState };
+// }
+
+// const answerUI = {
+
+// }

--- a/test/fixtures/seeduxUIExtractorFixtures.js
+++ b/test/fixtures/seeduxUIExtractorFixtures.js
@@ -101,7 +101,7 @@ BrowserifyTestTodoList1.propTypes = {
 // TODO: Handle nested propTypes
 // Simulates code injected into React-Redux's native Connect function
 
-function seeduxConnectLogic(WrappedComponent) {
+function seeduxReactReduxConnectLogic(WrappedComponent) {
   const UI = WrappedComponent.name;
 	if (WrappedComponent.propTypes) {
 		const props = Object.keys(WrappedComponent.propTypes);
@@ -114,10 +114,10 @@ function seeduxConnectLogic(WrappedComponent) {
 	}
 }
 
-const webpackTestUI1 = seeduxConnectLogic(WebpackTestTodoList1);
-const webpackTestUI2 = seeduxConnectLogic(WebpackTestTodoList2);
-const browserifyTestUI1 = seeduxConnectLogic(BrowserifyTestTodoList1);
-const browserifyTestUI2 = seeduxConnectLogic(BrowserifyTestTodoList2);
+const webpackTestUI1 = seeduxReactReduxConnectLogic(WebpackTestTodoList1);
+const webpackTestUI2 = seeduxReactReduxConnectLogic(WebpackTestTodoList2);
+const browserifyTestUI1 = seeduxReactReduxConnectLogic(BrowserifyTestTodoList1);
+const browserifyTestUI2 = seeduxReactReduxConnectLogic(BrowserifyTestTodoList2);
 
 const answerUI = {
   'name': 'Containers',

--- a/test/seeduxActionExtractorTests.js
+++ b/test/seeduxActionExtractorTests.js
@@ -1,8 +1,10 @@
 const chai = require('chai');
 const expect = require('chai').expect;
-const { testActionCreators, answerActionCreators } = require('./fixtures/seeduxActionExtractorFixtures');
+const { testActionCreators, testActionCreators2, testActionCreators3, answerActionCreators, answerActionCreators2, answerActionCreators3 } = require('./fixtures/seeduxActionExtractorFixtures');
 const { actionCreatorsExtractor, Node } = require('./../lib/seedux/src/seeduxExtractor');
 const output = actionCreatorsExtractor(testActionCreators);
+const output2 = actionCreatorsExtractor(testActionCreators2);
+const output3 = actionCreatorsExtractor(testActionCreators3);
 
 describe('actionCreatorsExtractor', () => {
 
@@ -17,8 +19,16 @@ describe('actionCreatorsExtractor', () => {
   })
 
 
-  it('should return a properly structured D3 hierarchical tree output for a given input', () => {
+  it('should return a properly structured D3 hierarchical tree output for a given input where type is a string', () => {
     expect(output).to.deep.equal(answerActionCreators);
+  })
+
+  it('should return a properly structured D3 hierarchical tree output for a given input where type is a variable', () => {
+    expect(output2).to.deep.equal(answerActionCreators2);
+  })
+
+  it('should return a properly structured D3 hierarchical tree output for a given input where type is a property', () => {
+    expect(output3).to.deep.equal(answerActionCreators3);
   })
 
 });


### PR DESCRIPTION
COMPLETED:
- Added regex tests as conditional statements to determine whether a developer's action type is written as a string, var, or property and parse accordingly
- Created ng test and fixtures files

NEXT STEPS:
- Refactor actionCreatorsExtractor by creating an assembleActionCreatorsNode function
- Refactor actionCreatorsExtractor's string action type parsing logic with a functional approach
- Brainstorm approaches to parsing ng-redux 