### PR TITLE
Removes repetitive language in 'How to Install' section 

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,16 +24,16 @@ Seedux can be easily installed as a developer dependency with npm using your fav
 npm install seedux --save-dev
 ```
 
-### Developer Version
+### Development Version
 
-Fork and Clone (developer version)
-
-To use Seedux development version, fork and clone our Git repository to an easily accessible file path on your computer and run the build:
+For a codebase suitable for modification, clone our git repository to an easily accessible file path on your computer and run the build:
 
 ```javascript
 cd seedux_repo_path
 npm run build:both
 ```
+
+In the examples below, replace 'seedux' with your repo path!
 
 ## Getting Started:
 

--- a/seeduxChrome/src/app.jsx
+++ b/seeduxChrome/src/app.jsx
@@ -229,8 +229,9 @@ class App extends React.Component {
           {this.createViz(this.state.reducers, 'Reducers')}
         </div>
         <select value={this.state.value} onChange={this.handleSelectChange.bind(this)} style = { vizSelectSetting }>
-          <option value="comfyTree">ComfyTree</option>
-          <option value="cozyTree">CozyTree</option>
+          <option value="comfyTree">Comfy Tree</option>
+          <option value="cozyTree">Cozy Tree</option>
+          <option value="basicList">Basic List</option>
         </select>
         <div style = { transactionLogSetting }>
           <button onClick={() => this.resetLog()}>Reset Log</button>

--- a/seeduxChrome/src/d3helpers.js
+++ b/seeduxChrome/src/d3helpers.js
@@ -1,4 +1,4 @@
-import { select, cluster, hierarchy, append } from 'd3';
+import { select, tree, hierarchy, append } from 'd3';
 
 // default chart size and spacing constants
 const config = {};
@@ -28,15 +28,15 @@ config.comfyTree = {
 
 };
 
-// config.list = {
-//   CHART_WIDTH: 250,
-//   CHART_HEIGHT: 250,
-//   DEPTH_SPACING_FACTOR: 0.25,
-//   BREADTH_SPACING_FACTOR: 0.25,
-//   RECT_HEIGHT: 20,
-//   RECT_WIDTH: 50,
+config.list = {
+  CHART_WIDTH: 250,
+  CHART_HEIGHT: 250,
+  DEPTH_SPACING_FACTOR: 0.25,
+  BREADTH_SPACING_FACTOR: 0.25,
+  RECT_HEIGHT: 20,
+  RECT_WIDTH: 50,
 
-// };
+};
 
 const exports = {};
 
@@ -51,81 +51,38 @@ exports.transformVizNode = function transformVizNode(element, data, type = 'cozy
   } else if (type === 'cozyTree') {
     buildBasicTree(element, data, config.cozyTree, searchTerm)
   }
-  // else if (type === 'list') {
-  //   buildBasicList(element, data, config.list, searchTerm);
-  // }
+  else if (type === 'list') {
+    buildBasicList(element, data, config.list, searchTerm);
+  }
 };
-// function buildBasicList(element, data, config, searchTerm) {
-//   //
-//   //
-//   //
-//   // creates the cluster differently
-//   //
-//   //
-//   const { CHART_WIDTH, CHART_HEIGHT, DEPTH_SPACING_FACTOR,
-//     BREADTH_SPACING_FACTOR, RECT_HEIGHT, RECT_WIDTH } = config;
-//   let svg = select(element)
-//     .append('svg')
-//     .attr('width', CHART_WIDTH)
-//     .attr('height', CHART_HEIGHT)
-//     .append('g')
-//     .attr('transform', 'translate(20,0)');
+function buildBasicList(element, data, config, searchTerm) {
+  let svg = select(element)
+  .append('svg')
+  .attr('width', CHART_WIDTH)
+  .attr('height', CHART_HEIGHT)
+  .append('g')
+  .attr('transform', 'translate(20,0)');
 
+  var layout = d3.layout.indent()
+  .children(function(d) { return d.children; })
+  .nodeSize([10, 15])
+  .separation(function(node, previousNode) { return node.parent === previousNode.parent || node.parent === previousNode ? 1 : 2; });
 
-//   let ourCluster = cluster()
-//     .size([CHART_HEIGHT * BREADTH_SPACING_FACTOR, CHART_WIDTH * DEPTH_SPACING_FACTOR])
-//     .separation(function(a, b) {
-//       return a.parent == b.parent ? 2 : 3;
-//     });
-//   // passes hierarchiacal data into cluster to create the root node
-//   let nodeHierarchy = hierarchy(data);
+  const nodes = layout(data);
 
-//   ourCluster(nodeHierarchy);
+  labels = svg.selectAll(".label")
+        .data(nodes, function(d) { return d.name });
 
-//   // entering the nodes --> finally appending to DOM
-//   let nodeEnter = svg.selectAll('.node')
-//     .data(nodeHierarchy.descendants())
-//     .enter()
-//     .append('g')
-//     .attr('class', function(d) {
-//       return 'node' + (d.children ? 'node-internal' : 'node-leaf');
-//     })
-//     .attr('transform', function(d) {
-//       console.log(d.y);
-//       return 'translate(' + d.y + ',' + (d.x) + ')';
-//     });
-
-//   //creating links
-
-//   let link = svg.selectAll('.node')
-//     .data(nodeHierarchy.descendants()
-//       .slice(1))
-//     .enter()
-//     .append('path')
-//     .attr('class', 'link')
-//     .attr('d', function(d) {
-//       return `M ${d.y} ${d.x}
-//         Q ${(d.parent.y)} ${(d.x + d.parent.x) / 2}
-//           ${d.parent.y} ${d.parent.x}`;
-//     })
-//     .attr('stroke-width', '1')
-//     .attr('stroke', 'darkblue')
-//     .attr('fill', 'none');
-
-//   // console.log(link)
-
-//     nodeEnter.append('rect')
-//       .attr('y', -RECT_HEIGHT / 2)
-//       .attr('height', RECT_HEIGHT)
-//       .attr('width', RECT_WIDTH)
-//       .style('fill', 'lightsteelblue');
-
-//   nodeEnter.append('text')
-//     .text(function(d) {
-//       return d.data.name;
-//     })
-//     .style('fill', 'darkblue');
-// }
+    labels.enter()
+        .append("text")
+        .attr({
+          "class": "label",
+          dy: ".35em",
+          transform: function(d) { return "translate(" + (d.x - 200) + "," + d.y + ")"; }
+        })
+        .style("font-weight", function(d) { return d.Country ? null : "bold" })
+        .text(function(d) { return id(d); });
+}
 
 function buildBasicTree(element, data, config, searchTerm) {
   const { CHART_WIDTH, CHART_HEIGHT, DEPTH_SPACING_FACTOR, BREADTH_SPACING_FACTOR, NODE_RADIUS } = config;
@@ -135,14 +92,15 @@ function buildBasicTree(element, data, config, searchTerm) {
   .attr('height', CHART_HEIGHT)
   .append('g')
   .attr('transform', 'translate(20,0)');
-  let ourCluster = cluster()
+  let ourCluster = tree()
     .size([CHART_HEIGHT * BREADTH_SPACING_FACTOR, CHART_WIDTH * DEPTH_SPACING_FACTOR])
     .separation(function(a, b) {
       return a.parent == b.parent ? 2 : 3;
     });
-  // passes hierarchiacal data into cluster to create the root node
-  let nodeHierarchy = hierarchy(data);
+  // passes hierarchiacal data into tree to create the root node
 
+  let nodeHierarchy = hierarchy(data);
+  // let nodeHierarchy = data;
   ourCluster(nodeHierarchy);
 
   // entering the nodes --> finally appending to DOM


### PR DESCRIPTION
We had something like 'developer version' three times in three sentences...also forking is not necessary to use the git version, so I changed simply to 'clone'.