### PR TITLE
Node illumination in linear time complexity achieved!

### DIFF
--- a/lib/react-redux/src/components/connect.js
+++ b/lib/react-redux/src/components/connect.js
@@ -56,7 +56,7 @@ export default function connect(mapStateToProps, mapDispatchToProps, mergeProps,
   // seedux
   let mappedStateString = mapState.toString();
   let mappedDispatchString = mapDispatch.toString();
-  let mappedPropsString = `${mappedStateString}${mappedDispatchString}`;
+  let mappedPropsString = `${mappedStateString}|${mappedDispatchString}`;
 
   return function wrapWithConnect(WrappedComponent) {
 

--- a/lib/seedux/src/seeduxAssembler.js
+++ b/lib/seedux/src/seeduxAssembler.js
@@ -11,17 +11,18 @@ function Node(name) {
   this.name = name;
 }
 
-function assembleUINodes(uiName, uiPropNames, uiMapState) {
+function assembleUINodes(uiName, uiPropNames = [], uiMapState = []) {
   const uiNameNode = new Node(uiName);
-    console.log('assembling ui nodes!', uiPropNames)
+    // console.log('assembling ui nodes!', uiPropNames)
   if (uiPropNames) {
     uiNameNode.children = [];
     uiPropNames.forEach(p => uiNameNode.children.push(new Node(p)));
   }
+  // console.log('adding container name node to viz...', uiNameNode)
   uiHeadNode.children.push(uiNameNode);
   parsedCodeObj.ui = uiHeadNode;
-  parsedCodeObj.uiLookUpResources[uiMapState.uiName] = uiMapState.uiName;
-  console.log('uiHeadNode', uiHeadNode)
+  parsedCodeObj.uiResources[uiMapState.uiName] = uiMapState.uiName;
+  // console.log('uiHeadNode', uiHeadNode)
   return uiHeadNode;
 };
 

--- a/lib/seedux/src/seeduxAssembler.js
+++ b/lib/seedux/src/seeduxAssembler.js
@@ -1,0 +1,77 @@
+const parsedCodeObj = {};
+parsedCodeObj.uiResources = {};
+const uiHeadNode = new Node('Containers');
+uiHeadNode.children = [];
+
+/**
+ * Functional Node constructor used to assemble hierarchical tree objects.
+ */
+
+function Node(name) {
+  this.name = name;
+}
+
+function assembleUINodes(uiName, uiPropNames, uiMapState) {
+  const uiNameNode = new Node(uiName);
+    console.log('assembling ui nodes!', uiPropNames)
+  if (uiPropNames) {
+    uiNameNode.children = [];
+    uiPropNames.forEach(p => uiNameNode.children.push(new Node(p)));
+  }
+  uiHeadNode.children.push(uiNameNode);
+  parsedCodeObj.ui = uiHeadNode;
+  parsedCodeObj.uiLookUpResources[uiMapState.uiName] = uiMapState.uiName;
+  console.log('uiHeadNode', uiHeadNode)
+  return uiHeadNode;
+};
+
+// resetUIHeadNode is used purely for testing purposes to assure uiHeadNode does not persist data between tests
+
+function resetUIHeadNode() {
+  return uiHeadNode.children = [];
+}
+
+function assembleReducerNodes(reducers, reducerNames, reducerCases = []) {
+  const headNode = new Node('Reducers');
+  headNode.children = [];
+  reducerNames.forEach((name, i) => {
+    const reducerNode = new Node(name);
+    reducerNode.children = [];
+      if (reducerCases[i]) {
+          reducerCases.forEach(c => {
+            if (reducers[name].includes(c)) {
+              reducerNode.children.push(new Node(c));
+            }
+          });
+      }
+    headNode.children.push(reducerNode);
+    parsedCodeObj.reducers = headNode;
+  });
+  return headNode;
+};
+
+function assembleActionCreatorNodes(actionCreatorNames, actionTypes) {
+  const headNode = new Node('Action Creators');
+  headNode.children = [];
+  actionCreatorNames.forEach((ac, i) => {
+    const actionCreatorNode = new Node(ac);
+    actionCreatorNode.children === undefined ? actionCreatorNode.children = [new Node(actionTypes[i])] : actionCreatorNode.children.push(new Node(actionTypes[i]));
+    headNode.children.push(actionCreatorNode);
+  });
+  parsedCodeObj.actionCreators = headNode;
+  parsedCodeObj.actionTypes = actionTypes;
+  return headNode;
+};
+
+// // attach a listener to respond with this data when the content script has loaded.
+// document.addEventListener('scriptLoaded', function(e) {
+//   // send message to background script with parsed code object
+//   // which was sent via e.detail property
+//   // // console.log('seeduxExtractor hears the content script!');
+//   var evt = document.createEvent('CustomEvent');
+//   evt.initCustomEvent('codeParsed', true, true, parsedCodeObj);
+//   // // console.log('EXTRACTOR: Dispatching event: ', evt);
+//   document.dispatchEvent(evt);
+// }, false);
+
+module.exports = { assembleUINodes, assembleReducerNodes, assembleActionCreatorNodes, resetUIHeadNode, Node };

--- a/lib/seedux/src/seeduxAssembler.js
+++ b/lib/seedux/src/seeduxAssembler.js
@@ -19,7 +19,7 @@ function assembleUINodes(uiName, uiPropNames = [], uiMapState = []) {
   }
   uiHeadNode.children.push(uiNameNode);
   parsedCodeObj.ui = uiHeadNode;
-  parsedCodeObj.uiResources[uiMapState.uiName] = uiMapState.uiName;
+  parsedCodeObj.uiResources[uiName] = uiMapState[uiName];
   return uiHeadNode;
 };
 
@@ -61,7 +61,6 @@ function assembleActionCreatorNodes(actionCreatorNames, actionTypes) {
   parsedCodeObj.actionCreators = headNode;
   parsedCodeObj.actionTypes = actionTypes;
   parsedCodeObj.actionMap = actionMap;
-  // console.log('actionMap', actionMap)
   return headNode;
 };
 

--- a/lib/seedux/src/seeduxAssembler.js
+++ b/lib/seedux/src/seeduxAssembler.js
@@ -13,16 +13,13 @@ function Node(name) {
 
 function assembleUINodes(uiName, uiPropNames = [], uiMapState = []) {
   const uiNameNode = new Node(uiName);
-    // console.log('assembling ui nodes!', uiPropNames)
   if (uiPropNames) {
     uiNameNode.children = [];
     uiPropNames.forEach(p => uiNameNode.children.push(new Node(p)));
   }
-  // console.log('adding container name node to viz...', uiNameNode)
   uiHeadNode.children.push(uiNameNode);
   parsedCodeObj.ui = uiHeadNode;
   parsedCodeObj.uiResources[uiMapState.uiName] = uiMapState.uiName;
-  // console.log('uiHeadNode', uiHeadNode)
   return uiHeadNode;
 };
 
@@ -64,7 +61,7 @@ function assembleActionCreatorNodes(actionCreatorNames, actionTypes) {
   parsedCodeObj.actionCreators = headNode;
   parsedCodeObj.actionTypes = actionTypes;
   parsedCodeObj.actionMap = actionMap;
-  console.log('actionMap', actionMap)
+  // console.log('actionMap', actionMap)
   return headNode;
 };
 

--- a/lib/seedux/src/seeduxAssembler.js
+++ b/lib/seedux/src/seeduxAssembler.js
@@ -53,14 +53,18 @@ function assembleReducerNodes(reducers, reducerNames, reducerCases = []) {
 
 function assembleActionCreatorNodes(actionCreatorNames, actionTypes) {
   const headNode = new Node('Action Creators');
+  const actionMap = {};
   headNode.children = [];
   actionCreatorNames.forEach((ac, i) => {
     const actionCreatorNode = new Node(ac);
+    actionMap[ac] = actionTypes[i];
     actionCreatorNode.children === undefined ? actionCreatorNode.children = [new Node(actionTypes[i])] : actionCreatorNode.children.push(new Node(actionTypes[i]));
     headNode.children.push(actionCreatorNode);
   });
   parsedCodeObj.actionCreators = headNode;
   parsedCodeObj.actionTypes = actionTypes;
+  parsedCodeObj.actionMap = actionMap;
+  console.log('actionMap', actionMap)
   return headNode;
 };
 

--- a/lib/seedux/src/seeduxAssembler.js
+++ b/lib/seedux/src/seeduxAssembler.js
@@ -65,15 +65,15 @@ function assembleActionCreatorNodes(actionCreatorNames, actionTypes) {
   return headNode;
 };
 
-// // attach a listener to respond with this data when the content script has loaded.
-// document.addEventListener('scriptLoaded', function(e) {
-//   // send message to background script with parsed code object
-//   // which was sent via e.detail property
-//   // // console.log('seeduxExtractor hears the content script!');
-//   var evt = document.createEvent('CustomEvent');
-//   evt.initCustomEvent('codeParsed', true, true, parsedCodeObj);
-//   // // console.log('EXTRACTOR: Dispatching event: ', evt);
-//   document.dispatchEvent(evt);
-// }, false);
+// attach a listener to respond with this data when the content script has loaded.
+document.addEventListener('scriptLoaded', function(e) {
+  // send message to background script with parsed code object
+  // which was sent via e.detail property
+  // // console.log('seeduxExtractor hears the content script!');
+  var evt = document.createEvent('CustomEvent');
+  evt.initCustomEvent('codeParsed', true, true, parsedCodeObj);
+  // // console.log('EXTRACTOR: Dispatching event: ', evt);
+  document.dispatchEvent(evt);
+}, false);
 
 module.exports = { assembleUINodes, assembleReducerNodes, assembleActionCreatorNodes, resetUIHeadNode, Node };

--- a/lib/seedux/src/seeduxExtractor.js
+++ b/lib/seedux/src/seeduxExtractor.js
@@ -1,14 +1,4 @@
-const parsedCodeObj = {};
-const uiHeadNode = new Node('Containers');
-uiHeadNode.children = [];
-
-/**
- * Functional Node constructor used to assemble hierarchical tree objects.
- */
-
-function Node(name) {
-  this.name = name;
-}
+const { assembleUINodes, assembleReducerNodes, assembleActionCreatorNodes, resetUIHeadNode } = require('./seeduxAssembler');
 
 /**
 *
@@ -30,38 +20,72 @@ function uiExtractor(ui) {
   const defaultMapDispatchToProps = 'function defaultMapDispatchToProps(dispatch){return{dispatch:dispatch};}';
   let uiName = Object.keys(ui)[0];
   let uiPropNames = ui[uiName];
+  let mapStateToPropsDef, mapStateToPropsSplitAtKeys, mapDispatchToPropsDef, mapDispatchToPropsSplitAtKeys, uiStateKeys, uiActionCreators;
 
   if (uiPropNames.includes(defaultMapStateToProps)) {
     uiPropNames = uiPropNames.slice(defaultMapStateToProps.length);
+    mapDispatchToPropsDef = uiPropNames;
   }
 
   if (uiPropNames.includes(defaultMapDispatchToProps)) {
     uiPropNames = uiPropNames.slice(0, uiPropNames.length - defaultMapDispatchToProps.length);
+    mapStateToPropsDef = uiPropNames;
   }
 
   if (uiPropNames) {
+    if (!mapStateToPropsDef && !mapDispatchToPropsDef) {
+      const splitPropNames = uiPropNames.split('|');
+      mapStateToPropsDef = uiStateKeys = splitPropNames[0];
+      mapDispatchToPropsDef = uiActionCreators = splitPropNames[1];
+      mapStateToPropsSplitAtKeys = mapStateToPropsDef.split(',') || mapStateToPropsDef;
+      mapDispatchToPropsSplitAtKeys = mapDispatchToPropsDef.split(',') || mapDispatchToPropsDef;
+      console.log('mapStateToPropsDef', mapStateToPropsDef, 'mapDispatchToPropsDef', mapDispatchToPropsDef)
+      // split mapStateToPropsDef at 'state.' or 'store.'
+      if (mapStateToPropsDef.includes('state.')) {
+        let uiMapState = {};
+        uiMapState[uiName] = {};
+        uiStatePropNames = mapStateToPropsDef.split(':').map(subStr => subStr = subStr.slice(-1 * ((subStr.length - 1) - subStr.lastIndexOf(' ')))).filter(subStr => /[\w*]/gi.test(subStr));
+        uiDispatchPropNames = mapDispatchToPropsDef.split(':').map(subStr => subStr = subStr.slice(-1 * ((subStr.length - 1) - subStr.lastIndexOf(' ')))).filter(subStr => /[\w*]/gi.test(subStr));
+        uiStateKeys = uiStateKeys.split('state.').slice(1).map(subStr => subStr = subStr.replace(/[^\w+]/g, ''));
+        uiActionCreators = uiActionCreators.split('dispatch(').slice(1).map(subStr => subStr = subStr.slice(0, subStr.indexOf('(')));
+
+        uiStatePropNames.forEach(prop => {
+          uiMapState[uiName][prop] = []
+          uiStateKeys.forEach(key => {
+            mapStateToPropsSplitAtKeys.forEach(def => {
+              if (def.includes(key) && def.includes(prop)) {
+                uiMapState[uiName][prop].push(key);
+              }
+            })
+          })
+        })
+
+        uiDispatchPropNames.forEach(prop => {
+          uiMapState[uiName][prop] = [];
+          uiActionCreators.forEach(ac => {
+            mapDispatchToPropsSplitAtKeys.forEach(def => {
+              if (def.includes(ac) && def.includes(prop)) {
+                uiMapState[uiName][prop].push(ac);
+              }
+            })
+          })
+        })
+        console.log('uiMapState', uiMapState)
+        console.log('uiMapStateKeys', Object.keys(uiMapState[uiName]))
+      }
+    }
+    // else if (uiStatePropNames) {
+      
+    // }
+    // else if (uiDispatchPropNames) {
+
+    // }
     uiPropNames = uiPropNames.split(':').map(subStr => subStr = subStr.slice(-1 * ((subStr.length - 1) - subStr.lastIndexOf(' ')))).filter(subStr => /[\w*]/gi.test(subStr));
+    console.log('uiPropNames', uiPropNames)
   }
 
-  return assembleUINodes(uiName, uiPropNames);
+  return assembleUINodes(uiName, uiPropNames, uiMapState);
 };
-
-function assembleUINodes(uiName, uiPropNames) {
-  const uiNameNode = new Node(uiName);
-  if (uiPropNames) {
-    uiNameNode.children = [];
-    uiPropNames.forEach(p => uiNameNode.children.push(new Node(p)));
-  }
-  uiHeadNode.children.push(uiNameNode);
-  parsedCodeObj.ui = uiHeadNode;
-  return uiHeadNode;
-};
-
-// resetUIHeadNode is used purely for testing purposes to assure uiHeadNode does not persist children between tests
-
-function resetUIHeadNode() {
-  return uiHeadNode.children = [];
-}
 
 /**
 *
@@ -78,11 +102,9 @@ function resetUIHeadNode() {
 */
 
 function reducersExtractor(reducers) {
-  const headNode = new Node('Reducers')
   const reducerNames = Object.keys(reducers);
   const strReducers = JSON.stringify(reducers);
   let reducerCases;
-  headNode.children = [];
 
   if (strReducers.includes('switch')) {
     reducerCases = strReducers.split('case').slice(1).map(cases => cases.replace(/[^\w*:.]/g, '')).map(cases => cases = cases.slice(0, cases.indexOf(':')));
@@ -96,24 +118,7 @@ function reducersExtractor(reducers) {
   if (/\./.test(reducerCases)) {
     reducerCases = reducerCases.map(cases => cases = cases.slice(cases.indexOf('.') + 1));
   }
-  return assembleReducerNodes(headNode, reducers, reducerNames, reducerCases);
-};
-
-function assembleReducerNodes(headNode, reducers, reducerNames, reducerCases = []) {
-  reducerNames.forEach((reducer, i) => {
-    const reducerNode = new Node(reducer);
-    reducerNode.children = [];
-      if (reducerCases[i]) {
-          reducerCases.forEach(c => {
-            if (reducers[reducer].includes(c)) {
-              reducerNode.children.push(new Node(c));
-            }
-          });
-      }
-    headNode.children.push(reducerNode);
-    parsedCodeObj.reducers = headNode;
-  });
-return headNode;
+  return assembleReducerNodes(reducers, reducerNames, reducerCases);
 };
 
 /**
@@ -132,39 +137,15 @@ return headNode;
 */
 
 function actionCreatorsExtractor(actionCreators) {
-  const headNode = new Node('Action Creators');
   const actionCreatorNames = Object.keys(actionCreators);
   const strActionCreators = JSON.stringify(actionCreators);
   let actionTypes;
-  headNode.children = [];
 
   actionTypes = strActionCreators.split('type:').slice(1).map(subStr => subStr = subStr.slice(1, subStr.indexOf('\\')).replace(/[^\w*.]/g, ''));
   if (/\./.test(actionTypes)) {
     actionTypes = actionTypes.map(subStr => subStr = subStr.slice(subStr.indexOf('.') + 1));
   }
-  return assembleActionCreatorNodes(headNode, actionCreatorNames, actionTypes);
+  return assembleActionCreatorNodes(actionCreatorNames, actionTypes);
 };
 
-function assembleActionCreatorNodes(headNode, actionCreatorNames, actionTypes) {
-  actionCreatorNames.forEach((ac, i) => {
-    const actionCreatorNode = new Node(ac);
-    actionCreatorNode.children === undefined ? actionCreatorNode.children = [new Node(actionTypes[i])] : actionCreatorNode.children.push(new Node(actionTypes[i]));
-    headNode.children.push(actionCreatorNode);
-  });
-  parsedCodeObj.actionCreators = headNode;
-  parsedCodeObj.actionTypes = actionTypes;
-  return headNode;
-};
-
-// attach a listener to respond with this data when the content script has loaded.
-document.addEventListener('scriptLoaded', function(e) {
-  // send message to background script with parsed code object
-  // which was sent via e.detail property
-  // // console.log('seeduxExtractor hears the content script!');
-  var evt = document.createEvent('CustomEvent');
-  evt.initCustomEvent('codeParsed', true, true, parsedCodeObj);
-  // // console.log('EXTRACTOR: Dispatching event: ', evt);
-  document.dispatchEvent(evt);
-}, false);
-
-module.exports = { uiExtractor, actionCreatorsExtractor, reducersExtractor, resetUIHeadNode, Node };
+module.exports = { uiExtractor, actionCreatorsExtractor, reducersExtractor, resetUIHeadNode };

--- a/lib/seedux/src/seeduxExtractor.js
+++ b/lib/seedux/src/seeduxExtractor.js
@@ -16,7 +16,6 @@ const { assembleUINodes, assembleReducerNodes, assembleActionCreatorNodes, reset
 */
 
 function uiExtractor(ui) {
-  console.log('ui', ui)
   const defaultMapStateToProps = 'function defaultMapStateToProps(state){return{};}';
   const defaultMapDispatchToProps = 'function defaultMapDispatchToProps(dispatch){return{dispatch:dispatch};}';
   let uiName = Object.keys(ui)[0];
@@ -25,17 +24,20 @@ function uiExtractor(ui) {
   let uiMapState = {};
   uiMapState[uiName] = {};
 
-  if (uiPropNames.includes(defaultMapStateToProps)) {
+  if (uiPropNames.includes(defaultMapStateToProps) && uiPropNames.includes(defaultMapDispatchToProps)) {
+    uiPropNames = false;
+  }
+
+  else if (uiPropNames.includes(defaultMapStateToProps)) {
     uiPropNames = uiPropNames.slice(defaultMapStateToProps.length);
     mapDispatchToPropsDef = uiPropNames;
   }
 
-  if (uiPropNames.includes(defaultMapDispatchToProps)) {
+  else if (uiPropNames.includes(defaultMapDispatchToProps)) {
     uiPropNames = uiPropNames.slice(0, uiPropNames.length - defaultMapDispatchToProps.length);
     mapStateToPropsDef = uiPropNames;
   }
 
-  console.log('uiPropNames', uiPropNames)
   if (uiPropNames) {
     if (!mapStateToPropsDef && !mapDispatchToPropsDef) {
       const splitPropNames = uiPropNames.split('|');
@@ -43,12 +45,14 @@ function uiExtractor(ui) {
       mapDispatchToPropsDef = uiActionCreators = splitPropNames[1];
       mapStateToPropsSplitAtKeys = mapStateToPropsDef.split(',') || mapStateToPropsDef;
       mapDispatchToPropsSplitAtKeys = mapDispatchToPropsDef.split(',') || mapDispatchToPropsDef;
-      // console.log('mapStateToPropsDef', mapStateToPropsDef, 'mapDispatchToPropsDef', mapDispatchToPropsDef)
-      // split mapStateToPropsDef at 'state.' or 'store.'
       if (mapStateToPropsDef.includes('state.')) {
+        uiStateKeys = uiStateKeys.split('state.').slice(1).map(subStr => subStr = subStr.replace(/[^\w+]/g, ''));
+      }
+      else if (mapStateToPropsDef.includes('store.')) {
+        uiStateKeys = uiStateKeys.split('store.').slice(1).map(subStr => subStr = subStr.replace(/[^\w+]/g, ''));
+      }
         uiStatePropNames = mapStateToPropsDef.split(':').map(subStr => subStr = subStr.slice(-1 * ((subStr.length - 1) - subStr.lastIndexOf(' ')))).filter(subStr => /[\w*]/gi.test(subStr));
         uiDispatchPropNames = mapDispatchToPropsDef.split(':').map(subStr => subStr = subStr.slice(-1 * ((subStr.length - 1) - subStr.lastIndexOf(' ')))).filter(subStr => /[\w*]/gi.test(subStr));
-        uiStateKeys = uiStateKeys.split('state.').slice(1).map(subStr => subStr = subStr.replace(/[^\w+]/g, ''));
         uiActionCreators = uiActionCreators.split('dispatch(').slice(1).map(subStr => subStr = subStr.slice(0, subStr.indexOf('(')));
 
         uiStatePropNames.forEach(prop => {
@@ -72,18 +76,9 @@ function uiExtractor(ui) {
             })
           })
         })
-        // console.log('uiMapState', uiMapState)
-        // console.log('uiMapStateKeys', Object.keys(uiMapState[uiName]))
-      }
-    }
-    // else if (uiStatePropNames) {
       
-    // }
-    // else if (uiDispatchPropNames) {
-
-    // }
+    }
     uiPropNames = uiPropNames.split(':').map(subStr => subStr = subStr.slice(-1 * ((subStr.length - 1) - subStr.lastIndexOf(' ')))).filter(subStr => /[\w*]/gi.test(subStr));
-    // console.log('uiPropNames', uiPropNames)
   }
 
   return assembleUINodes(uiName, uiPropNames, uiMapState);

--- a/lib/seedux/src/seeduxExtractor.js
+++ b/lib/seedux/src/seeduxExtractor.js
@@ -20,7 +20,8 @@ function uiExtractor(ui) {
   const defaultMapDispatchToProps = 'function defaultMapDispatchToProps(dispatch){return{dispatch:dispatch};}';
   let uiName = Object.keys(ui)[0];
   let uiPropNames = ui[uiName];
-  let mapStateToPropsDef, mapStateToPropsSplitAtKeys, mapDispatchToPropsDef, mapDispatchToPropsSplitAtKeys, uiStateKeys, uiActionCreators;
+  console.log('uiPropNames', uiPropNames)
+  let mapStateToPropsDef, mapStateToPropsSplitAtKeys, mapDispatchToPropsDef, mapDispatchToPropsSplitAtKeys, uiStateKeys, uiStatePropNames, uiDispatchPropNames, uiActionCreators;
   let uiMapState = {};
   uiMapState[uiName] = {};
 
@@ -43,20 +44,22 @@ function uiExtractor(ui) {
       const splitPropNames = uiPropNames.split('|');
       mapStateToPropsDef = uiStateKeys = splitPropNames[0];
       mapDispatchToPropsDef = uiActionCreators = splitPropNames[1];
-      mapStateToPropsSplitAtKeys = mapStateToPropsDef.split(',') || mapStateToPropsDef;
-      mapDispatchToPropsSplitAtKeys = mapDispatchToPropsDef.split(',') || mapDispatchToPropsDef;
+      mapStateToPropsSplitAtKeys = mapStateToPropsDef.split(','); // || mapStateToPropsDef;
+      mapDispatchToPropsSplitAtKeys = mapDispatchToPropsDef.split(','); // || mapDispatchToPropsDef;
       if (mapStateToPropsDef.includes('state.')) {
-        uiStateKeys = uiStateKeys.split('state.').slice(1).map(subStr => subStr = subStr.replace(/[^\w+]/g, ''));
+        uiStateKeys = uiStateKeys.split('state.').slice(1).map(subStr => subStr = subStr.slice(0, subStr.lastIndexOf('.'))).map(subStr => subStr.replace(/[^\w.]/gi, ''));
       }
       else if (mapStateToPropsDef.includes('store.')) {
-        uiStateKeys = uiStateKeys.split('store.').slice(1).map(subStr => subStr = subStr.replace(/[^\w+]/g, ''));
+        uiStateKeys = uiStateKeys.split('store.').slice(1).map(subStr => subStr = subStr.slice(0, subStr.lastIndexOf('.'))).map(subStr => subStr.replace(/[^\w.]/gi, ''));
       }
         uiStatePropNames = mapStateToPropsDef.split(':').map(subStr => subStr = subStr.slice(-1 * ((subStr.length - 1) - subStr.lastIndexOf(' ')))).filter(subStr => /[\w*]/gi.test(subStr));
         uiDispatchPropNames = mapDispatchToPropsDef.split(':').map(subStr => subStr = subStr.slice(-1 * ((subStr.length - 1) - subStr.lastIndexOf(' ')))).filter(subStr => /[\w*]/gi.test(subStr));
         uiActionCreators = uiActionCreators.split('dispatch(').slice(1).map(subStr => subStr = subStr.slice(0, subStr.indexOf('(')));
 
+        // Debug creation of uiMapState
+
         uiStatePropNames.forEach(prop => {
-          uiMapState[uiName][prop] = []
+          uiMapState[uiName][prop] = [];
           uiStateKeys.forEach(key => {
             mapStateToPropsSplitAtKeys.forEach(def => {
               if (def.includes(key) && def.includes(prop)) {
@@ -65,17 +68,16 @@ function uiExtractor(ui) {
             })
           })
         })
-
-        uiDispatchPropNames.forEach(prop => {
-          uiMapState[uiName][prop] = [];
-          uiActionCreators.forEach(ac => {
-            mapDispatchToPropsSplitAtKeys.forEach(def => {
-              if (def.includes(ac) && def.includes(prop)) {
-                uiMapState[uiName][prop].push(ac);
-              }
-            })
-          })
-        })
+        // uiDispatchPropNames.forEach(prop => {
+        //   uiMapState[uiName][prop] = [];
+        //   uiActionCreators.forEach(ac => {
+        //     mapDispatchToPropsSplitAtKeys.forEach(def => {
+        //       if (def.includes(ac) && def.includes(prop)) {
+        //         uiMapState[uiName][prop].push(ac);
+        //       }
+        //     })
+        //   })
+        // })
       
     }
     uiPropNames = uiPropNames.split(':').map(subStr => subStr = subStr.slice(-1 * ((subStr.length - 1) - subStr.lastIndexOf(' ')))).filter(subStr => /[\w*]/gi.test(subStr));

--- a/lib/seedux/src/seeduxExtractor.js
+++ b/lib/seedux/src/seeduxExtractor.js
@@ -20,7 +20,6 @@ function uiExtractor(ui) {
   const defaultMapDispatchToProps = 'function defaultMapDispatchToProps(dispatch){return{dispatch:dispatch};}';
   let uiName = Object.keys(ui)[0];
   let uiPropNames = ui[uiName];
-  console.log('uiPropNames', uiPropNames)
   let mapStateToPropsDef, mapStateToPropsSplitAtKeys, mapDispatchToPropsDef, mapDispatchToPropsSplitAtKeys, uiStateKeys, uiStatePropNames, uiDispatchPropNames, uiActionCreators;
   let uiMapState = {};
   uiMapState[uiName] = {};
@@ -55,8 +54,6 @@ function uiExtractor(ui) {
         uiStatePropNames = mapStateToPropsDef.split(':').map(subStr => subStr = subStr.slice(-1 * ((subStr.length - 1) - subStr.lastIndexOf(' ')))).filter(subStr => /[\w*]/gi.test(subStr));
         uiDispatchPropNames = mapDispatchToPropsDef.split(':').map(subStr => subStr = subStr.slice(-1 * ((subStr.length - 1) - subStr.lastIndexOf(' ')))).filter(subStr => /[\w*]/gi.test(subStr));
         uiActionCreators = uiActionCreators.split('dispatch(').slice(1).map(subStr => subStr = subStr.slice(0, subStr.indexOf('(')));
-
-        // Debug creation of uiMapState
 
         uiStatePropNames.forEach(prop => {
           uiMapState[uiName][prop] = [];

--- a/lib/seedux/src/seeduxExtractor.js
+++ b/lib/seedux/src/seeduxExtractor.js
@@ -16,6 +16,7 @@ const { assembleUINodes, assembleReducerNodes, assembleActionCreatorNodes, reset
 */
 
 function uiExtractor(ui) {
+  console.log('ui', ui)
   const defaultMapStateToProps = 'function defaultMapStateToProps(state){return{};}';
   const defaultMapDispatchToProps = 'function defaultMapDispatchToProps(dispatch){return{dispatch:dispatch};}';
   let uiName = Object.keys(ui)[0];
@@ -34,6 +35,7 @@ function uiExtractor(ui) {
     mapStateToPropsDef = uiPropNames;
   }
 
+  console.log('uiPropNames', uiPropNames)
   if (uiPropNames) {
     if (!mapStateToPropsDef && !mapDispatchToPropsDef) {
       const splitPropNames = uiPropNames.split('|');

--- a/lib/seedux/src/seeduxExtractor.js
+++ b/lib/seedux/src/seeduxExtractor.js
@@ -21,6 +21,8 @@ function uiExtractor(ui) {
   let uiName = Object.keys(ui)[0];
   let uiPropNames = ui[uiName];
   let mapStateToPropsDef, mapStateToPropsSplitAtKeys, mapDispatchToPropsDef, mapDispatchToPropsSplitAtKeys, uiStateKeys, uiActionCreators;
+  let uiMapState = {};
+  uiMapState[uiName] = {};
 
   if (uiPropNames.includes(defaultMapStateToProps)) {
     uiPropNames = uiPropNames.slice(defaultMapStateToProps.length);
@@ -39,11 +41,9 @@ function uiExtractor(ui) {
       mapDispatchToPropsDef = uiActionCreators = splitPropNames[1];
       mapStateToPropsSplitAtKeys = mapStateToPropsDef.split(',') || mapStateToPropsDef;
       mapDispatchToPropsSplitAtKeys = mapDispatchToPropsDef.split(',') || mapDispatchToPropsDef;
-      console.log('mapStateToPropsDef', mapStateToPropsDef, 'mapDispatchToPropsDef', mapDispatchToPropsDef)
+      // console.log('mapStateToPropsDef', mapStateToPropsDef, 'mapDispatchToPropsDef', mapDispatchToPropsDef)
       // split mapStateToPropsDef at 'state.' or 'store.'
       if (mapStateToPropsDef.includes('state.')) {
-        let uiMapState = {};
-        uiMapState[uiName] = {};
         uiStatePropNames = mapStateToPropsDef.split(':').map(subStr => subStr = subStr.slice(-1 * ((subStr.length - 1) - subStr.lastIndexOf(' ')))).filter(subStr => /[\w*]/gi.test(subStr));
         uiDispatchPropNames = mapDispatchToPropsDef.split(':').map(subStr => subStr = subStr.slice(-1 * ((subStr.length - 1) - subStr.lastIndexOf(' ')))).filter(subStr => /[\w*]/gi.test(subStr));
         uiStateKeys = uiStateKeys.split('state.').slice(1).map(subStr => subStr = subStr.replace(/[^\w+]/g, ''));
@@ -70,8 +70,8 @@ function uiExtractor(ui) {
             })
           })
         })
-        console.log('uiMapState', uiMapState)
-        console.log('uiMapStateKeys', Object.keys(uiMapState[uiName]))
+        // console.log('uiMapState', uiMapState)
+        // console.log('uiMapStateKeys', Object.keys(uiMapState[uiName]))
       }
     }
     // else if (uiStatePropNames) {
@@ -81,7 +81,7 @@ function uiExtractor(ui) {
 
     // }
     uiPropNames = uiPropNames.split(':').map(subStr => subStr = subStr.slice(-1 * ((subStr.length - 1) - subStr.lastIndexOf(' ')))).filter(subStr => /[\w*]/gi.test(subStr));
-    console.log('uiPropNames', uiPropNames)
+    // console.log('uiPropNames', uiPropNames)
   }
 
   return assembleUINodes(uiName, uiPropNames, uiMapState);

--- a/lib/seedux/src/seeduxLookUp.js
+++ b/lib/seedux/src/seeduxLookUp.js
@@ -4,6 +4,8 @@ function populateTable(codeObj) {
   addActionCreatorsToTable(codeObj.actionCreators, codeObj.actionTypes);
   addReducersToTable(codeObj.reducers, codeObj.actionTypes);
   addUIToTable(codeObj.ui, codeObj.uiResources, codeObj.actionMap);
+  let d3TableKeys = Object.keys(d3Table);
+  d3TableKeys.forEach(key => { d3Table[key].push('APP'); })
   return d3Table;
 }
 

--- a/lib/seedux/src/seeduxLookUp.js
+++ b/lib/seedux/src/seeduxLookUp.js
@@ -1,0 +1,71 @@
+let d3LookUpTable = {};
+
+function populateLookUpTable(codeObj) {
+  // codeObj = { actionCreators, actionTypes, reducers, ui }
+  addActionCreatorsToLookupTable(codeObj.actionCreators, codeObj.actionTypes);
+  addReducersToLookupTable(codeObj.reducers, codeObj.actionTypes);
+  addUIToLookUpTable(codeObj.ui, codeObj.uiResources);
+  return d3LookUpTable;
+}
+
+function addUIToLookUpTable(ui, uiResources) {
+  const uiNameNodes = ui.children;
+  if (uiResources) {
+    uiNameNodes.forEach(node => {
+      let props = Object.keys(uiResources[node]);
+      props.forEach(prop => {
+        let d3LookUpTableKeys = Object.keys(d3LookUpTable);
+        let potentialActionTypeOrStateKey = uiResources[node][prop];
+        if (d3LookUpTableKeys.includes(potentialActionTypeOrStateKey)) {
+          d3LookUpTable[potentialActionTypeOrStateKey].push(prop);
+          if (!d3LookUpTable[potentialActionTypeOrStateKey].includes('Containers')) { d3LookUpTable[potentialActionTypeOrStateKey].push('Containers'); }
+        }
+        if (!d3LookUpTableKeys.includes(potentialActionTypeOrStateKey)) {
+          d3LookUpTable[potentialActionTypeOrStateKey] ? d3LookUpTable[potentialActionTypeOrStateKey].push(prop) : d3LookUpTable[potentialActionTypeOrStateKey] = [prop];
+          if (!d3LookUpTable[potentialActionTypeOrStateKey].includes('Containers')) { d3LookUpTable[potentialActionTypeOrStateKey].push('Containers'); }
+        }
+      })
+    })
+  }
+  return d3LookUpTable;
+}
+
+function addReducersToLookupTable(reducers, actionTypes = []) {
+  const reducerNameNodes = reducers.children;
+  if (actionTypes.length) {
+    actionTypes.forEach(a => {
+      if (!d3LookUpTable[a]) { d3LookUpTable[a] = []; };
+      reducerNameNodes.forEach(node => {
+        if (node.children.includes(a)) { 
+          d3LookUpTable[a].push(node.name);
+          if (!d3LookUpTable[a].includes('Reducers')) { d3LookUpTable[a].push('Reducers'); }
+        }
+      });
+    });
+  }
+  return d3LookUpTable;
+}
+
+function addActionCreatorsToLookupTable(actionCreators, actionTypes = []) {
+  const actionCreatorNameNodes = actionCreators.children;
+  if (actionTypes.length) {
+    actionTypes.forEach(a => {
+      if (!d3LookUpTable[a]) { d3LookUpTable[a] = []; };
+      actionCreatorNameNodes.forEach(node => {
+        if (node.children.includes(a)) {
+          d3LookUpTable[a].push(node.name);
+          if (!d3LookUpTable[a].includes('Action Creators')) { d3LookUpTable[a].push('Action Creators'); }
+        }
+      });
+    });
+  }
+  return d3LookUpTable;
+}
+
+// resetLookUpTable is used purely for testing purposes to assure d3LookUpTable does not persist data between tests
+
+function resetLookUpTable() {
+  return d3LookUpTable = {};
+}
+
+module.exports = { populateLookUpTable, addActionCreatorsToLookupTable, addReducersToLookupTable, resetLookUpTable };

--- a/lib/seedux/src/seeduxLookUp.js
+++ b/lib/seedux/src/seeduxLookUp.js
@@ -1,71 +1,86 @@
-let d3LookUpTable = {};
+let d3Table = {};
 
-function populateLookUpTable(codeObj) {
+function populateTable(codeObj) {
   // codeObj = { actionCreators, actionTypes, reducers, ui }
-  addActionCreatorsToLookupTable(codeObj.actionCreators, codeObj.actionTypes);
-  addReducersToLookupTable(codeObj.reducers, codeObj.actionTypes);
-  addUIToLookUpTable(codeObj.ui, codeObj.uiResources);
-  return d3LookUpTable;
+  addActionCreatorsToTable(codeObj.actionCreators, codeObj.actionTypes);
+  addReducersToTable(codeObj.reducers, codeObj.actionTypes);
+  addUIToTable(codeObj.ui, codeObj.uiResources);
+  return d3Table;
 }
 
-function addUIToLookUpTable(ui, uiResources) {
+function addUIToTable(ui, uiResources) {
   const uiNameNodes = ui.children;
   if (uiResources) {
     uiNameNodes.forEach(node => {
-      let props = Object.keys(uiResources[node]);
+      // console.log('uiResources', uiResources)
+      // console.log('nameNode', node)
+      let name = uiResources[node.name];
+      let props = Object.keys(name);
+      // console.log('props', props)
       props.forEach(prop => {
-        let d3LookUpTableKeys = Object.keys(d3LookUpTable);
-        let potentialActionTypeOrStateKey = uiResources[node][prop];
-        if (d3LookUpTableKeys.includes(potentialActionTypeOrStateKey)) {
-          d3LookUpTable[potentialActionTypeOrStateKey].push(prop);
-          if (!d3LookUpTable[potentialActionTypeOrStateKey].includes('Containers')) { d3LookUpTable[potentialActionTypeOrStateKey].push('Containers'); }
+        let d3TableKeys = Object.keys(d3Table);
+        let potentialActionTypeOrStateKey = name[prop];
+        if (d3TableKeys.includes(potentialActionTypeOrStateKey)) {
+          d3Table[potentialActionTypeOrStateKey].push(prop);
+          if (!d3Table[potentialActionTypeOrStateKey].includes(name)) { d3Table[potentialActionTypeOrStateKey].push(node.name); }
+          if (!d3Table[potentialActionTypeOrStateKey].includes('Containers')) { d3Table[potentialActionTypeOrStateKey].push('Containers'); }
         }
-        if (!d3LookUpTableKeys.includes(potentialActionTypeOrStateKey)) {
-          d3LookUpTable[potentialActionTypeOrStateKey] ? d3LookUpTable[potentialActionTypeOrStateKey].push(prop) : d3LookUpTable[potentialActionTypeOrStateKey] = [prop];
-          if (!d3LookUpTable[potentialActionTypeOrStateKey].includes('Containers')) { d3LookUpTable[potentialActionTypeOrStateKey].push('Containers'); }
+        if (!d3TableKeys.includes(potentialActionTypeOrStateKey)) {
+          d3Table[potentialActionTypeOrStateKey] ? d3Table[potentialActionTypeOrStateKey].push(prop) : d3Table[potentialActionTypeOrStateKey] = [prop];
+          if (!d3Table[potentialActionTypeOrStateKey].includes(name)) { d3Table[potentialActionTypeOrStateKey].push(node.name); }
+          if (!d3Table[potentialActionTypeOrStateKey].includes('Containers')) { d3Table[potentialActionTypeOrStateKey].push('Containers'); }
         }
       })
     })
   }
-  return d3LookUpTable;
+  console.log('d3Table', d3Table)
+  return d3Table;
 }
 
-function addReducersToLookupTable(reducers, actionTypes = []) {
+function addReducersToTable(reducers, actionTypes = []) {
   const reducerNameNodes = reducers.children;
   if (actionTypes.length) {
     actionTypes.forEach(a => {
-      if (!d3LookUpTable[a]) { d3LookUpTable[a] = []; };
+      if (!d3Table[a]) { d3Table[a] = []; };
       reducerNameNodes.forEach(node => {
-        if (node.children.includes(a)) { 
-          d3LookUpTable[a].push(node.name);
-          if (!d3LookUpTable[a].includes('Reducers')) { d3LookUpTable[a].push('Reducers'); }
+        if (node.children.length) { 
+          node.children.forEach(childNode => {
+            if (childNode.name === a) {
+              d3Table[a].push(node.name);
+              if (!d3Table[a].includes('Reducers')) { d3Table[a].push('Reducers'); }
+            }
+          })
         }
       });
     });
   }
-  return d3LookUpTable;
+  return d3Table;
 }
 
-function addActionCreatorsToLookupTable(actionCreators, actionTypes = []) {
+function addActionCreatorsToTable(actionCreators, actionTypes = []) {
   const actionCreatorNameNodes = actionCreators.children;
   if (actionTypes.length) {
     actionTypes.forEach(a => {
-      if (!d3LookUpTable[a]) { d3LookUpTable[a] = []; };
+      if (!d3Table[a]) { d3Table[a] = []; };
       actionCreatorNameNodes.forEach(node => {
-        if (node.children.includes(a)) {
-          d3LookUpTable[a].push(node.name);
-          if (!d3LookUpTable[a].includes('Action Creators')) { d3LookUpTable[a].push('Action Creators'); }
+        if (node.children.length) {
+          node.children.forEach(childNode => {
+            if (childNode.name === a) {
+              d3Table[a].push(node.name);
+              if (!d3Table[a].includes('Action Creators')) { d3Table[a].push('Action Creators'); }
+            }
+          })
         }
       });
     });
   }
-  return d3LookUpTable;
+  return d3Table;
 }
 
-// resetLookUpTable is used purely for testing purposes to assure d3LookUpTable does not persist data between tests
+// resetTable is used purely for testing purposes to assure d3Table does not persist data between tests
 
-function resetLookUpTable() {
-  return d3LookUpTable = {};
+function resetTable() {
+  return d3Table = {};
 }
 
-module.exports = { populateLookUpTable, addActionCreatorsToLookupTable, addReducersToLookupTable, resetLookUpTable };
+module.exports = { populateTable, addActionCreatorsToTable, addReducersToTable, addUIToTable, resetTable };

--- a/lib/seedux/src/seeduxLookUp.js
+++ b/lib/seedux/src/seeduxLookUp.js
@@ -1,39 +1,38 @@
 let d3Table = {};
 
 function populateTable(codeObj) {
-  // codeObj = { actionCreators, actionTypes, reducers, ui }
   addActionCreatorsToTable(codeObj.actionCreators, codeObj.actionTypes);
   addReducersToTable(codeObj.reducers, codeObj.actionTypes);
-  addUIToTable(codeObj.ui, codeObj.uiResources);
+  addUIToTable(codeObj.ui, codeObj.uiResources, codeObj.actionMap);
   return d3Table;
 }
 
-function addUIToTable(ui, uiResources) {
-  const uiNameNodes = ui.children;
-  if (uiResources) {
+function addUIToTable(ui, uiResources, actionMap) {
+  const uiNameNodes = ui.children; // Array of container node objects
+  let d3TableKeys = Object.keys(d3Table);
+  if (uiResources) { // Object with structure -> { container: { prop: [state or action creators] } }
     uiNameNodes.forEach(node => {
-      // console.log('uiResources', uiResources)
-      // console.log('nameNode', node)
-      let name = uiResources[node.name];
-      let props = Object.keys(name);
-      // console.log('props', props)
+      let name = uiResources[node.name]; // Look through container keys and uiResources
+      let props = Object.keys(name); // Props of container in format -> { prop: [state or action creators] }
       props.forEach(prop => {
-        let d3TableKeys = Object.keys(d3Table);
-        let potentialActionTypeOrStateKey = name[prop];
-        if (d3TableKeys.includes(potentialActionTypeOrStateKey)) {
-          d3Table[potentialActionTypeOrStateKey].push(prop);
-          if (!d3Table[potentialActionTypeOrStateKey].includes(name)) { d3Table[potentialActionTypeOrStateKey].push(node.name); }
-          if (!d3Table[potentialActionTypeOrStateKey].includes('Containers')) { d3Table[potentialActionTypeOrStateKey].push('Containers'); }
-        }
-        if (!d3TableKeys.includes(potentialActionTypeOrStateKey)) {
-          d3Table[potentialActionTypeOrStateKey] ? d3Table[potentialActionTypeOrStateKey].push(prop) : d3Table[potentialActionTypeOrStateKey] = [prop];
-          if (!d3Table[potentialActionTypeOrStateKey].includes(name)) { d3Table[potentialActionTypeOrStateKey].push(node.name); }
-          if (!d3Table[potentialActionTypeOrStateKey].includes('Containers')) { d3Table[potentialActionTypeOrStateKey].push('Containers'); }
-        }
+        let potentialActionCreatorOrStateArr = name[prop]; // Array of action creators or state keys
+        potentialActionCreatorOrStateArr.forEach(p => {
+          if (actionMap[p]) {
+            let actionType = actionMap[p];
+            d3Table[actionType] ? d3Table[actionType].push(prop) : d3Table[actionType] = [prop];
+            if (!d3Table[actionType].includes(name)) { d3Table[actionType].push(node.name); }
+            if (!d3Table[actionType].includes('Containers')) { d3Table[actionType].push('Containers'); }
+          }
+          else {
+            let stateKey = p; 
+            d3TableKeys.includes(stateKey) ? d3Table[stateKey].push(prop) : d3Table[stateKey] = [prop]; 
+            if (!d3Table[stateKey].includes(name)) { d3Table[stateKey].push(node.name); }
+            if (!d3Table[stateKey].includes('Containers')) { d3Table[stateKey].push('Containers'); }
+          }
+        });
       })
     })
   }
-  console.log('d3Table', d3Table)
   return d3Table;
 }
 

--- a/package.json
+++ b/package.json
@@ -4,14 +4,16 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "mocha ./test/*",
     "build:extension": "webpack -w --config extension-webpack.config.js",
     "build:library": "webpack -w --config library-webpack.config.js",
     "build:both": "webpack -w --config extension-webpack.config.js | webpack -w --config library-webpack.config.js",
     "build:production:extension": "webpack --config extension-webpack.config.js",
     "build:production:library": "NODE_ENV=development webpack --config npm-webpack.config.js",
     "build:production:both": "webpack --config extension-webpack.config.js && NODE_ENV=development webpack --config npm-webpack.config.js",
-    "dev": "webpack-dev-server --hot --inline -w"
+    "dev": "webpack-dev-server --hot --inline -w",
+    "test": "mocha ./test/*",
+    "test:extractor": "mocha ./test/seeduxActionExtractorTests.js ./test/seeduxReducersExtractorTests.js ./test/seeduxUIExtractorTests.js",
+    "test:lookup": "mocha ./test/seeduxLookUpTests.js"
   },
   "keywords": [],
   "author": "",

--- a/seeduxChrome/background/background.js
+++ b/seeduxChrome/background/background.js
@@ -19,6 +19,7 @@ let codeObj = {
 let future = [];
 let tabId = 0;
 let freezeLog = false;
+let d3LookUpTable = {};
 
 chrome.runtime.onMessage.addListener((msg, sender, response) => {
   console.log('Background got MSG: ', msg);
@@ -72,6 +73,9 @@ chrome.runtime.onMessage.addListener((msg, sender, response) => {
       Object.assign(codeObj, msg.codeObj);
       codeObj.count++;
     }
+
+    d3LookUpTable = populateLookUpTable(codeObj);
+
     // console.log('Got New CodeObj: ', msg.codeObj);
     // console.log('Aggregated CodeObj:', codeObj);
     // store the app's tab ID for use later in passing

--- a/seeduxChrome/background/background.js
+++ b/seeduxChrome/background/background.js
@@ -32,7 +32,7 @@ chrome.runtime.onMessage.addListener((msg, sender, response) => {
   // sent by extension to ask for initial log and codeObj data
   if (msg.type === 'populateLog') {
     freezeLog = msg.settings.freezeLog;
-    response({ future, history, codeObj });
+    response({ future, history, codeObj, d3LookUpTable });
   }
   // sent by extension to reset the log
   if (msg.type === 'resetLog') {
@@ -68,13 +68,13 @@ chrome.runtime.onMessage.addListener((msg, sender, response) => {
     // memory on a 'third' (ie the new App's first) codeObj message.
     if (codeObj.count === 2) {
       codeObj = Object.assign({}, msg.codeObj);
+      d3LookUpTable = populateLookUpTable(codeObj);
       codeObj.count = 1;
     } else {
       Object.assign(codeObj, msg.codeObj);
       codeObj.count++;
     }
 
-    d3LookUpTable = populateLookUpTable(codeObj);
 
     // console.log('Got New CodeObj: ', msg.codeObj);
     // console.log('Aggregated CodeObj:', codeObj);

--- a/seeduxChrome/background/background.js
+++ b/seeduxChrome/background/background.js
@@ -1,3 +1,96 @@
+// To-do: bundle seeduxLookUp.js
+
+let d3Table = {};
+
+function populateTable(codeObj) {
+  addActionCreatorsToTable(codeObj.actionCreators, codeObj.actionTypes);
+  addReducersToTable(codeObj.reducers, codeObj.actionTypes);
+  addUIToTable(codeObj.ui, codeObj.uiResources, codeObj.actionMap);
+  let d3TableKeys = Object.keys(d3Table);
+  d3TableKeys.forEach(key => { d3Table[key].push('APP'); })
+  console.log('heres the table', d3Table)
+  return d3Table;
+}
+
+function addUIToTable(ui, uiResources, actionMap) {
+  const uiNameNodes = ui.children; // Array of container node objects
+  let d3TableKeys = Object.keys(d3Table);
+  if (uiResources) { // Object with structure -> { container: { prop: [state or action creators] } }
+    uiNameNodes.forEach(node => {
+      let name = uiResources[node.name]; // Look through container keys and uiResources
+      let props = Object.keys(name); // Props of container in format -> { prop: [state or action creators] }
+      props.forEach(prop => {
+        let potentialActionCreatorOrStateArr = name[prop]; // Array of action creators or state keys
+        potentialActionCreatorOrStateArr.forEach(p => {
+          if (actionMap[p]) {
+            let actionType = actionMap[p];
+            d3Table[actionType] ? d3Table[actionType].push(prop) : d3Table[actionType] = [prop];
+            if (!d3Table[actionType].includes(name)) { d3Table[actionType].push(node.name); }
+            if (!d3Table[actionType].includes('Containers')) { d3Table[actionType].push('Containers'); }
+          }
+          else {
+            let stateKey = p; 
+            d3TableKeys.includes(stateKey) ? d3Table[stateKey].push(prop) : d3Table[stateKey] = [prop]; 
+            if (!d3Table[stateKey].includes(name)) { d3Table[stateKey].push(node.name); }
+            if (!d3Table[stateKey].includes('Containers')) { d3Table[stateKey].push('Containers'); }
+          }
+        });
+      })
+    })
+  }
+  return d3Table;
+}
+
+function addReducersToTable(reducers, actionTypes = []) {
+  const reducerNameNodes = reducers.children;
+  if (actionTypes.length) {
+    actionTypes.forEach(a => {
+      if (!d3Table[a]) { d3Table[a] = []; };
+      reducerNameNodes.forEach(node => {
+        if (node.children.length) { 
+          node.children.forEach(childNode => {
+            if (childNode.name === a) {
+              d3Table[a].push(node.name);
+              if (!d3Table[a].includes('Reducers')) { d3Table[a].push('Reducers'); }
+            }
+          })
+        }
+      });
+    });
+  }
+  return d3Table;
+}
+
+function addActionCreatorsToTable(actionCreators, actionTypes = []) {
+  const actionCreatorNameNodes = actionCreators.children;
+  if (actionTypes.length) {
+    actionTypes.forEach(a => {
+      if (!d3Table[a]) { d3Table[a] = []; };
+      actionCreatorNameNodes.forEach(node => {
+        if (node.children.length) {
+          node.children.forEach(childNode => {
+            if (childNode.name === a) {
+              d3Table[a].push(node.name);
+              if (!d3Table[a].includes('Action Creators')) { d3Table[a].push('Action Creators'); }
+            }
+          })
+        }
+      });
+    });
+  }
+  return d3Table;
+}
+
+// resetTable is used purely for testing purposes to assure d3Table does not persist data between tests
+
+function resetTable() {
+  return d3Table = {};
+}
+
+// import { populateTable } from './../../lib/src/seeduxLookUp';
+
+
+
 /* global chrome */
 /**
  * Listens for events in the seedux life-cycle. Triggered when a message is sent
@@ -19,7 +112,7 @@ let codeObj = {
 let future = [];
 let tabId = 0;
 let freezeLog = false;
-let d3LookUpTable = {};
+// let d3Table = {};
 
 chrome.runtime.onMessage.addListener((msg, sender, response) => {
   console.log('Background got MSG: ', msg);
@@ -32,7 +125,9 @@ chrome.runtime.onMessage.addListener((msg, sender, response) => {
   // sent by extension to ask for initial log and codeObj data
   if (msg.type === 'populateLog') {
     freezeLog = msg.settings.freezeLog;
-    response({ future, history, codeObj, d3LookUpTable });
+    d3Table = populateTable(codeObj);
+    console.log('populating log...')
+    response({ future, history, codeObj, d3Table });
   }
   // sent by extension to reset the log
   if (msg.type === 'resetLog') {
@@ -68,7 +163,6 @@ chrome.runtime.onMessage.addListener((msg, sender, response) => {
     // memory on a 'third' (ie the new App's first) codeObj message.
     if (codeObj.count === 2) {
       codeObj = Object.assign({}, msg.codeObj);
-      d3LookUpTable = populateLookUpTable(codeObj);
       codeObj.count = 1;
     } else {
       Object.assign(codeObj, msg.codeObj);

--- a/seeduxChrome/src/app.jsx
+++ b/seeduxChrome/src/app.jsx
@@ -248,7 +248,6 @@ class App extends React.Component {
         }
       });
     }
-    console.log('generateSearchTerms', searchTerms)
     return searchTerms;
   }
   render() {

--- a/seeduxChrome/src/app.jsx
+++ b/seeduxChrome/src/app.jsx
@@ -142,7 +142,11 @@ class App extends React.Component {
       <ParsingError failureType={name} /> :
       <D3Viz data={data}
         chartType={this.state.settings.chartType}
-        searchTerm = { this.state.history.length ? this.state.history[this.state.history.length - 1].modifiedAction.type : null } />
+        d3LookUpTable = { this.state.d3LookUpTable }
+
+        // Add additional search term(s) of state keys with changed values
+
+        searchTerms = { this.state.history.length ? this.state.history[this.state.history.length - 1].modifiedAction.type : null } />
   }
   stashLog() {
     localStorage.setItem('seeduxLog', makeStashableLog(this.state, false));
@@ -239,7 +243,7 @@ class App extends React.Component {
           <SettingsMenu toggleSettings = {this.toggleSettings.bind(this)} settings = {this.state.settings}/>
         </span>
         <div className='chart-container'>
-          <D3Viz data={this.assembleVizData()} style = { vizSelectSetting} chartType={this.state.settings.chartType} searchTerm = { this.state.history.length ? this.state.history[this.state.history.length - 1].modifiedAction.type : null }/>
+          <D3Viz data={this.assembleVizData()} style = { vizSelectSetting} chartType={this.state.settings.chartType} d3LookUpTable = { this.state.d3LookUpTable }  searchTerm = { this.state.history.length ? this.state.history[this.state.history.length - 1].modifiedAction.type : null }/>
         </div>
         <select value={this.state.settings.chartType} onChange={this.handleSelectChange.bind(this)} style = { vizSelectSetting }>
           <option value="fancyTree">Fancy Tree</option>

--- a/seeduxChrome/src/app.jsx
+++ b/seeduxChrome/src/app.jsx
@@ -46,6 +46,7 @@ class App extends React.Component {
       actionTypes: [],
       reducers: {},
       ui: {},
+      d3LookUpTable: {},
       chartType: 'comfyTree',
       flashMessage: getGreetings(),
     };
@@ -66,6 +67,7 @@ class App extends React.Component {
           actionTypes: response.codeObj.actionTypes || [],
           history: response.history,
           future: response.future,
+          d3LookUpTable: response.d3LookUpTable
         });
     });
 

--- a/seeduxChrome/src/components/D3Viz.jsx
+++ b/seeduxChrome/src/components/D3Viz.jsx
@@ -8,11 +8,11 @@ class D3Viz extends Component {
   }
 
   render() {
-    const { data, chartType, searchTerm } = this.props;
+    const { data, chartType, d3LookUpTable, searchTerms } = this.props;
     // //--- D3 LOGIC -----////
     // The canvas for the tree//
     const fauxNode = ReactFauxDom.createElement('div');
-    transformVizNode(fauxNode, data, chartType, searchTerm);
+    transformVizNode(fauxNode, data, chartType, d3LookUpTable, searchTerms);
     return fauxNode.toReact();
   }
 }

--- a/seeduxChrome/src/components/D3Viz.jsx
+++ b/seeduxChrome/src/components/D3Viz.jsx
@@ -8,11 +8,11 @@ class D3Viz extends Component {
   }
 
   render() {
-    const { data, chartType, d3LookUpTable, searchTerms } = this.props;
+    const { data, chartType, d3Table, searchTerms } = this.props;
     // //--- D3 LOGIC -----////
     // The canvas for the tree//
     const fauxNode = ReactFauxDom.createElement('div');
-    transformVizNode(fauxNode, data, chartType, d3LookUpTable, searchTerms);
+    transformVizNode(fauxNode, data, chartType, d3Table, searchTerms);
     return fauxNode.toReact();
   }
 }

--- a/seeduxChrome/src/d3helpers.js
+++ b/seeduxChrome/src/d3helpers.js
@@ -60,17 +60,17 @@ const exports = {};
 
 // takes in DOM element to be transformed into DefaultCluster,
 // && data that the DefaultCluster visualizes
-exports.transformVizNode = function transformVizNode(element, data, type = 'cozyTree', d3LookUpTable, searchTerms = null) {
+exports.transformVizNode = function transformVizNode(element, data, type = 'cozyTree', d3Table, searchTerms = null) {
   if (type === 'comfyTree') {
-    buildBasicTree(element, data, config.comfyTree, d3LookUpTable, searchTerms);
+    buildBasicTree(element, data, config.comfyTree, d3Table, searchTerms);
   } else if (type === 'cozyTree') {
-    buildBasicTree(element, data, config.cozyTree, d3LookUpTable, searchTerms)
+    buildBasicTree(element, data, config.cozyTree, d3Table, searchTerms)
   }
   else if (type === 'fancyTree') {
-    buildFancyTree(element, data, config.fancyTree, d3LookUpTable, searchTerms);
+    buildFancyTree(element, data, config.fancyTree, d3Table, searchTerms);
   }
 };
-function buildBasicList(element, data, config, d3LookUpTable, searchTerms) {
+function buildBasicList(element, data, config, d3Table, searchTerms) {
   let svg = select(element)
   .append('svg')
   .attr('width', CHART_WIDTH)
@@ -99,7 +99,7 @@ function buildBasicList(element, data, config, d3LookUpTable, searchTerms) {
         .text(function(d) { return id(d); });
 }
 
-function buildBasicTree(element, data, config, searchTerms) {
+function buildBasicTree(element, data, config, d3Table, searchTerms = false) {
   const { CHART_WIDTH, CHART_HEIGHT, DEPTH_SPACING_FACTOR, BREADTH_SPACING_FACTOR, NODE_RADIUS, LINK_WEIGHT } = config;
   let svg = select(element)
   .append('svg')
@@ -150,9 +150,11 @@ function buildBasicTree(element, data, config, searchTerms) {
     .style('fill', function(d) {
       let color = 'lightsteelblue';
       if (searchTerms) {
-        if (d3LookUpTable[searchTerms].includes(d.data.name)) {
-          color = 'yellow';
-        }
+        searchTerms.forEach(term => {
+          if (d3Table[term].includes(d.data.name)) {
+            color = 'yellow';
+          }
+        })
       }
       return color;
     });
@@ -169,7 +171,8 @@ function project(x, y) {
   return [radius * Math.cos(angle), radius * Math.sin(angle)];
 }
 
-function buildFancyTree(element, data, config, d3LookUpTable, searchTerms) {
+function buildFancyTree(element, data, config, d3Table, searchTerms = false) {
+          console.log('d3Table', d3Table)
   const { CHART_WIDTH, CHART_HEIGHT, DEPTH_SPACING_FACTOR, BREADTH_SPACING_FACTOR, NODE_RADIUS, LINK_WEIGHT } = config;
   let svg = select(element)
   .append('svg')
@@ -222,10 +225,15 @@ function buildFancyTree(element, data, config, d3LookUpTable, searchTerms) {
     .attr('r', NODE_RADIUS)
     .style('fill', function(d) {
       let color = 'lightsteelblue';
-      if (searchTerms) {
-        if (d3LookUpTable[searchTerms].includes(d.data.name)) {
-          color = 'yellow';
-        }
+      if (searchTerms.length) {
+      console.log('searchTerms', searchTerms)
+        searchTerms.forEach(term => {
+          if (d3Table[term]) {
+            if (d3Table[term].includes(d.data.name)) {
+              color = 'yellow';
+            }
+          }
+        })
       }
       return color;
     });

--- a/seeduxChrome/src/d3helpers.js
+++ b/seeduxChrome/src/d3helpers.js
@@ -151,8 +151,10 @@ function buildBasicTree(element, data, config, d3Table, searchTerms = false) {
       let color = 'lightsteelblue';
       if (searchTerms) {
         searchTerms.forEach(term => {
-          if (d3Table[term].includes(d.data.name)) {
-            color = 'yellow';
+          if (d3Table[term]) {
+            if (d3Table[term].includes(d.data.name)) {
+              color = 'yellow';
+            }
           }
         })
       }

--- a/seeduxChrome/src/d3helpers.js
+++ b/seeduxChrome/src/d3helpers.js
@@ -228,7 +228,6 @@ function buildFancyTree(element, data, config, d3Table, searchTerms = false) {
     .style('fill', function(d) {
       let color = 'lightsteelblue';
       if (searchTerms.length) {
-      console.log('searchTerms', searchTerms)
         searchTerms.forEach(term => {
           if (d3Table[term]) {
             if (d3Table[term].includes(d.data.name)) {

--- a/seeduxChrome/src/d3helpers.js
+++ b/seeduxChrome/src/d3helpers.js
@@ -60,17 +60,17 @@ const exports = {};
 
 // takes in DOM element to be transformed into DefaultCluster,
 // && data that the DefaultCluster visualizes
-exports.transformVizNode = function transformVizNode(element, data, type = 'cozyTree', searchTerm = null) {
+exports.transformVizNode = function transformVizNode(element, data, type = 'cozyTree', d3LookUpTable, searchTerms = null) {
   if (type === 'comfyTree') {
-    buildBasicTree(element, data, config.comfyTree, searchTerm);
+    buildBasicTree(element, data, config.comfyTree, d3LookUpTable, searchTerms);
   } else if (type === 'cozyTree') {
-    buildBasicTree(element, data, config.cozyTree, searchTerm)
+    buildBasicTree(element, data, config.cozyTree, d3LookUpTable, searchTerms)
   }
   else if (type === 'fancyTree') {
-    buildFancyTree(element, data, config.fancyTree, searchTerm);
+    buildFancyTree(element, data, config.fancyTree, d3LookUpTable, searchTerms);
   }
 };
-function buildBasicList(element, data, config, searchTerm) {
+function buildBasicList(element, data, config, d3LookUpTable, searchTerms) {
   let svg = select(element)
   .append('svg')
   .attr('width', CHART_WIDTH)
@@ -99,7 +99,7 @@ function buildBasicList(element, data, config, searchTerm) {
         .text(function(d) { return id(d); });
 }
 
-function buildBasicTree(element, data, config, searchTerm) {
+function buildBasicTree(element, data, config, searchTerms) {
   const { CHART_WIDTH, CHART_HEIGHT, DEPTH_SPACING_FACTOR, BREADTH_SPACING_FACTOR, NODE_RADIUS, LINK_WEIGHT } = config;
   let svg = select(element)
   .append('svg')
@@ -149,22 +149,8 @@ function buildBasicTree(element, data, config, searchTerm) {
     .attr('r', NODE_RADIUS)
     .style('fill', function(d) {
       let color = 'lightsteelblue';
-      if (searchTerm) {
-        if (d.data.children) {
-          d.data.children.forEach(node => {
-            if (node.name === searchTerm) {
-              color = 'yellow';
-            }
-            else if (node.children) {
-              node.children.forEach(childNode => {
-                if (childNode.name === searchTerm) {
-                  color = 'yellow';
-                }
-              })
-            }
-          })
-        }
-        else if (d.data.name === searchTerm) {
+      if (searchTerms) {
+        if (d3LookUpTable[searchTerms].includes(d.data.name)) {
           color = 'yellow';
         }
       }
@@ -183,7 +169,7 @@ function project(x, y) {
   return [radius * Math.cos(angle), radius * Math.sin(angle)];
 }
 
-function buildFancyTree(element, data, config, searchTerm) {
+function buildFancyTree(element, data, config, d3LookUpTable, searchTerms) {
   const { CHART_WIDTH, CHART_HEIGHT, DEPTH_SPACING_FACTOR, BREADTH_SPACING_FACTOR, NODE_RADIUS, LINK_WEIGHT } = config;
   let svg = select(element)
   .append('svg')
@@ -236,22 +222,8 @@ function buildFancyTree(element, data, config, searchTerm) {
     .attr('r', NODE_RADIUS)
     .style('fill', function(d) {
       let color = 'lightsteelblue';
-      if (searchTerm) {
-        if (d.data.children) {
-          d.data.children.forEach(node => {
-            if (node.name === searchTerm) {
-              color = 'yellow';
-            }
-            else if (node.children) {
-              node.children.forEach(childNode => {
-                if (childNode.name === searchTerm) {
-                  color = 'yellow';
-                }
-              })
-            }
-          })
-        }
-        else if (d.data.name === searchTerm) {
+      if (searchTerms) {
+        if (d3LookUpTable[searchTerms].includes(d.data.name)) {
           color = 'yellow';
         }
       }

--- a/test/fixtures/seeduxLookUpFixtures.js
+++ b/test/fixtures/seeduxLookUpFixtures.js
@@ -102,6 +102,10 @@ const testUIResources = {
   } 
 };
 
+const testActionMap = { 
+  toggleTodo: 'TOGGLE_TODO'
+}
+
 const answerActionCreators = {
   'ADD_TODO': ['addTodo', 'Action Creators'],
   'SET_VISIBILITY_FILTER': ['setVisibilityFilter', 'Action Creators'],
@@ -122,4 +126,4 @@ const answerUI = {
   'visibilityFilter': ['todos', 'WebpackTestTodoList', 'Containers']
 }
 
-module.exports = { testActionCreators, testReducers, testUI, testUIResources, testActionTypes1, testActionTypes2, answerActionCreators, answerReducers };
+module.exports = { testActionCreators, testReducers, testUI, testUIResources, testActionMap, testActionTypes1, testActionTypes2, answerActionCreators, answerReducers, answerUI };

--- a/test/fixtures/seeduxLookUpFixtures.js
+++ b/test/fixtures/seeduxLookUpFixtures.js
@@ -126,4 +126,23 @@ const answerUI = {
   'visibilityFilter': ['todos', 'WebpackTestTodoList', 'Containers']
 }
 
-module.exports = { testActionCreators, testReducers, testUI, testUIResources, testActionMap, testActionTypes1, testActionTypes2, answerActionCreators, answerReducers, answerUI };
+const testCodeObj = {
+  actionCreators: testActionCreators,
+  actionTypes: testActionTypes2,
+  reducers: testReducers,
+  ui: testUI,
+  uiResources: testUIResources,
+  actionMap: testActionMap
+}
+
+const answerTable = {
+  'ADD_TODO': ['addTodo', 'Action Creators', 'todos', 'Reducers', 'APP'],
+  'SET_VISIBILITY_FILTER': ['setVisibilityFilter', 'Action Creators', 'visibilityFilter', 'Reducers', 'APP'],
+  'TOGGLE_TODO': ['toggleTodo', 'Action Creators', 'todos', 'Reducers', 'onTodoClick', 'WebpackTestTodoList', 'Containers', 'APP'],
+  'UNDO': ['undoAction', 'Action Creators', 'APP'],
+  'REDO': ['redoAction', 'Action Creators', 'APP'],
+  'todos': ['todos', 'WebpackTestTodoList', 'Containers', 'APP'],
+  'visibilityFilter': ['todos', 'WebpackTestTodoList', 'Containers', 'APP']
+}
+
+module.exports = { testActionCreators, testReducers, testUI, testUIResources, testActionMap, testActionTypes1, testActionTypes2, answerActionCreators, answerReducers, answerUI, answerTable, testCodeObj };

--- a/test/fixtures/seeduxLookUpFixtures.js
+++ b/test/fixtures/seeduxLookUpFixtures.js
@@ -1,0 +1,116 @@
+const testActionCreators = {
+  'name': 'Action Creators',
+  'children': [
+    {
+      'name': 'addTodo',
+      'children': [
+        {
+          'name': 'ADD_TODO'
+        }
+      ]
+    },
+    {
+      'name': 'setVisibilityFilter',
+      'children': [
+        {
+          'name': 'SET_VISIBILITY_FILTER'
+        }
+      ]
+    },
+    {
+      'name': 'toggleTodo',
+      'children': [
+        {
+          'name': 'TOGGLE_TODO'
+        }
+      ]
+    },
+    {
+      'name': 'undoAction',
+      'children': [
+        {
+          'name': 'UNDO'
+        }
+      ]
+    },
+    {
+      'name': 'redoAction',
+      'children': [
+        {
+          'name': 'REDO'
+        }
+      ]
+    }
+  ]
+}
+
+const testReducers = {
+  'name': 'Reducers',
+  'children': [
+      {
+        'name': 'visibilityFilter',
+        'children': [
+          {
+            'name': 'SET_VISIBILITY_FILTER'
+          }
+        ]
+      },
+      {
+        'name': 'todos',
+        'children': [
+          {
+            'name': 'ADD_TODO'
+          },
+          {
+            'name': 'TOGGLE_TODO'
+          }
+        ]
+      }
+  ]
+}
+
+const testActionTypes1 = ['ADD_TODO', 'SET_VISIBILITY_FILTER', 'TOGGLE_TODO', 'UNDO', 'REDO'];
+const testActionTypes2 = ['SET_VISIBILITY_FILTER', 'ADD_TODO', 'TOGGLE_TODO'];
+
+const testUI = {
+  'name': 'Containers',
+  'children': [
+		{
+      'name': 'WebpackTestTodoList',
+      'children': [
+        {
+          'name': 'todos'
+        },
+				{
+					'name': 'onTodoClick'
+				}
+      ]
+    }
+  ]
+};
+
+const testUIResources = { 
+  WebpackTestTodoList: 
+  { 
+    todos: [ 'todos' ], 
+    onTodoClick: [ 'toggleTodo' ] 
+  } 
+};
+
+const answerActionCreators = {
+  'ADD_TODO': ['addTodo', 'Action Creators'],
+  'SET_VISIBILITY_FILTER': ['setVisibilityFilter', 'Action Creators'],
+  'TOGGLE_TODO': ['toggleTodo', 'Action Creators'],
+  'UNDO': ['undoAction', 'Action Creators'],
+  'REDO': ['redoAction', 'Action Creators']
+}
+
+const answerReducers = {
+  'SET_VISIBILITY_FILTER': ['visibilityFilter', 'Reducers'],
+  'ADD_TODO': ['todos', 'Reducers'],
+  'TOGGLE_TODO': ['todos', 'Reducers']
+}
+
+// const answerUI;
+
+module.exports = { testActionCreators, testReducers, testUI, testUIResources, testActionTypes1, testActionTypes2, answerActionCreators, answerReducers };

--- a/test/fixtures/seeduxLookUpFixtures.js
+++ b/test/fixtures/seeduxLookUpFixtures.js
@@ -69,8 +69,13 @@ const testReducers = {
   ]
 }
 
-const testActionTypes1 = ['ADD_TODO', 'SET_VISIBILITY_FILTER', 'TOGGLE_TODO', 'UNDO', 'REDO'];
-const testActionTypes2 = ['SET_VISIBILITY_FILTER', 'ADD_TODO', 'TOGGLE_TODO'];
+// testActionTypes1 corresponds with testReducers
+
+const testActionTypes1 = ['SET_VISIBILITY_FILTER', 'ADD_TODO', 'TOGGLE_TODO'];
+
+// testActionTypes2 corresponds with testActionCreators
+
+const testActionTypes2 = ['ADD_TODO', 'SET_VISIBILITY_FILTER', 'TOGGLE_TODO', 'UNDO', 'REDO'];
 
 const testUI = {
   'name': 'Containers',
@@ -92,7 +97,7 @@ const testUI = {
 const testUIResources = { 
   WebpackTestTodoList: 
   { 
-    todos: [ 'todos' ], 
+    todos: [ 'todos', 'visibilityFilter' ], 
     onTodoClick: [ 'toggleTodo' ] 
   } 
 };
@@ -111,6 +116,10 @@ const answerReducers = {
   'TOGGLE_TODO': ['todos', 'Reducers']
 }
 
-// const answerUI;
+const answerUI = {
+  'TOGGLE_TODO': ['onTodoClick', 'WebpackTestTodoList', 'Containers'],
+  'todos': ['todos', 'WebpackTestTodoList', 'Containers'],
+  'visibilityFilter': ['todos', 'WebpackTestTodoList', 'Containers']
+}
 
 module.exports = { testActionCreators, testReducers, testUI, testUIResources, testActionTypes1, testActionTypes2, answerActionCreators, answerReducers };

--- a/test/fixtures/seeduxUIExtractorFixtures.js
+++ b/test/fixtures/seeduxUIExtractorFixtures.js
@@ -34,6 +34,50 @@ const mapDispatchToPropsTestTodoList = (dispatch) => {
     }
   }
 }
+	var TestLink = function TestLink(_ref) {
+	  var active = _ref.active,
+	      children = _ref.children,
+	      _onClick = _ref.onClick;
+
+	  if (active) {
+	    return _react2.default.createElement(
+	      "span",
+	      null,
+	      children
+	    );
+	  }
+
+	  return _react2.default.createElement(
+	    "a",
+	    { href: "#",
+	      onClick: function onClick(e) {
+	        e.preventDefault();
+	        _onClick();
+	      }
+	    },
+	    children
+	  );
+	};
+
+	TestLink.propTypes = {
+	  active: _react.PropTypes.bool.isRequired,
+	  children: _react.PropTypes.node.isRequired,
+	  onClick: _react.PropTypes.func.isRequired
+	};
+
+function mapStateToPropsTestLink(state, ownProps) {
+	  return {
+	    active: ownProps.filter === state.visibilityFilter
+	  };
+	}
+
+function mapDispatchToPropsTestLink(dispatch, ownProps) {
+	  return {
+	    onClick: function onClick() {
+	      dispatch((0, _actions.setVisibilityFilter)(ownProps.filter));
+	    }
+	  };
+	}
 
 // Browserified TodoList:
 
@@ -98,6 +142,7 @@ const webpackTestUI1 = seeduxReactReduxConnectLogic(mapStateToPropsTestTodoList,
 const webpackTestUI2 = seeduxReactReduxConnectLogic(false, false)(WebpackTestTodoList);
 const webpackTestUI3 = seeduxReactReduxConnectLogic(mapStateToPropsTestTodoList)(WebpackTestTodoList)
 const webpackTestUI4 = seeduxReactReduxConnectLogic('test', mapDispatchToPropsTestTodoList)(WebpackTestTodoList)
+const webpackTestUI5 = seeduxReactReduxConnectLogic(mapStateToPropsTestLink, mapDispatchToPropsTestLink)(TestLink);
 const browserifyTestUI1 = seeduxReactReduxConnectLogic(mapStateToPropsTestTodoList, mapDispatchToPropsTestTodoList)(BrowserifyTestTodoList);
 
 const answerUI1 = {
@@ -158,6 +203,23 @@ const answerUI5 = {
   'name': 'Containers',
   'children': [
 		{
+			'name': 'TestLink',
+			'children': [
+				{
+					'name': 'active'
+				},
+				{
+					'name': 'onClick'
+				}
+			]
+		}
+	]
+}
+
+const answerUI6 = {
+  'name': 'Containers',
+  'children': [
+		{
 			'name': 'BrowserifyTestTodoList',
 			'children': [
 				{
@@ -171,4 +233,5 @@ const answerUI5 = {
 	]
 }
 
-module.exports = { webpackTestUI1, webpackTestUI2, webpackTestUI3, webpackTestUI4, browserifyTestUI1, WebpackTestTodoList, BrowserifyTestTodoList, answerUI1, answerUI2, answerUI2, answerUI3, answerUI4, answerUI5 };
+
+module.exports = { webpackTestUI1, webpackTestUI2, webpackTestUI3, webpackTestUI4, webpackTestUI5, browserifyTestUI1, WebpackTestTodoList, BrowserifyTestTodoList, answerUI1, answerUI2, answerUI2, answerUI3, answerUI4, answerUI5, answerUI6 };

--- a/test/fixtures/seeduxUIExtractorFixtures.js
+++ b/test/fixtures/seeduxUIExtractorFixtures.js
@@ -90,6 +90,7 @@ function seeduxReactReduxConnectLogic(mapStateToProps, mapDispatchToProps) {
   return function wrapWithConnect(WrappedComponent) {
 
   const UI = WrappedComponent.name; 
+  // console.log('obj passed to extractor', {[UI]: mappedPropsString})
   return {[UI]: mappedPropsString};
 	}
 }

--- a/test/fixtures/seeduxUIExtractorFixtures.js
+++ b/test/fixtures/seeduxUIExtractorFixtures.js
@@ -85,12 +85,11 @@ function seeduxReactReduxConnectLogic(mapStateToProps, mapDispatchToProps) {
 		mappedDispatchString = mapDispatchToProps;
 	}
 
-  let mappedPropsString = `${mappedStateString}${mappedDispatchString}`;
+  let mappedPropsString = `${mappedStateString}|${mappedDispatchString}`;
 
   return function wrapWithConnect(WrappedComponent) {
 
   const UI = WrappedComponent.name; 
-	console.log('Initial obj for extractor passed...', {[UI]: mappedPropsString})
   return {[UI]: mappedPropsString};
 	}
 }

--- a/test/fixtures/seeduxUIExtractorFixtures.js
+++ b/test/fixtures/seeduxUIExtractorFixtures.js
@@ -90,13 +90,12 @@ function seeduxReactReduxConnectLogic(mapStateToProps, mapDispatchToProps) {
   return function wrapWithConnect(WrappedComponent) {
 
   const UI = WrappedComponent.name; 
-  // console.log('obj passed to extractor', {[UI]: mappedPropsString})
   return {[UI]: mappedPropsString};
 	}
 }
 
 const webpackTestUI1 = seeduxReactReduxConnectLogic(mapStateToPropsTestTodoList, mapDispatchToPropsTestTodoList)(WebpackTestTodoList);
-const webpackTestUI2 = seeduxReactReduxConnectLogic()(WebpackTestTodoList);
+const webpackTestUI2 = seeduxReactReduxConnectLogic(false, false)(WebpackTestTodoList);
 const webpackTestUI3 = seeduxReactReduxConnectLogic(mapStateToPropsTestTodoList)(WebpackTestTodoList)
 const webpackTestUI4 = seeduxReactReduxConnectLogic('test', mapDispatchToPropsTestTodoList)(WebpackTestTodoList)
 const browserifyTestUI1 = seeduxReactReduxConnectLogic(mapStateToPropsTestTodoList, mapDispatchToPropsTestTodoList)(BrowserifyTestTodoList);

--- a/test/seeduxActionExtractorTests.js
+++ b/test/seeduxActionExtractorTests.js
@@ -1,7 +1,9 @@
 const chai = require('chai');
 const expect = require('chai').expect;
 const { testActionCreators, testActionCreators2, testActionCreators3, testActionCreators4, answerActionCreators, answerActionCreators2, answerActionCreators3, answerActionCreators4 } = require('./fixtures/seeduxActionExtractorFixtures');
-const { actionCreatorsExtractor, Node } = require('./../lib/seedux/src/seeduxExtractor');
+const { actionCreatorsExtractor } = require('./../lib/seedux/src/seeduxExtractor');
+// const { Node } = require('./../lib/seedux/src/seeduxAssembler');
+const assemblerUtils = require('./../lib/seedux/src/seeduxAssembler');
 const output = actionCreatorsExtractor(testActionCreators);
 const output2 = actionCreatorsExtractor(testActionCreators2);
 const output3 = actionCreatorsExtractor(testActionCreators3);
@@ -10,12 +12,12 @@ const output4 = actionCreatorsExtractor(testActionCreators4)
 describe('actionCreatorsExtractor', () => {
 
   it('should be a function', () => {
-    expect(actionCreatorsExtractor).to.be.a.function;
+    expect(actionCreatorsExtractor).to.be.a('function');
   })
 
   it('should return an object-typed instance of Node named "Action Creators"', () => {
     expect(output).to.be.an('object');
-    expect(output.constructor).to.deep.equal(Node);
+    expect(output.constructor).to.deep.equal(assemblerUtils.Node);
     expect(output.name).to.deep.equal('Action Creators');
   })
 
@@ -43,13 +45,13 @@ describe('"Action Creators" node', () => {
   it('should have an array-typed property named children composed of object-typed Node(s)', () => {
     expect(output.children).to.be.an('array');
     expect(output.children[0]).to.be.an('object');
-    expect(output.children[0].constructor).to.deep.equal(Node);
+    expect(output.children[0].constructor).to.deep.equal(assemblerUtils.Node);
   })
 
   it('should have child nodes that each possess an array-typed property named children composed of object-typed Node(s)', () => {
     expect(output.children[0].children).to.be.an('array');
     expect(output.children[0].children[0]).to.be.an('object');
-    expect(output.children[0].children[0].constructor).to.deep.equal(Node);
+    expect(output.children[0].children[0].constructor).to.deep.equal(assemblerUtils.Node);
   })
 
 });

--- a/test/seeduxAngularExtractorTests.js
+++ b/test/seeduxAngularExtractorTests.js
@@ -1,14 +1,15 @@
 const chai = require('chai');
 const expect = require('chai').expect;
 // const { testUI, testUI2, TestTodoList, TestTodoList2, answerUI } = require('./fixtures/seeduxUIExtractorFixtures');
-const { uiExtractor, Node } = require('./../lib/seedux/src/seeduxExtractor');
+const { uiExtractor } = require('./../lib/seedux/src/seeduxExtractor');
+const { Node } = require('./../lib/seedux/src/seeduxAssembler');
 // const output = uiExtractor(testUI);
 // const output2 = uiExtractor(testUI2);
 
 xdescribe('uiExtractor (Angular)', () => {
 
   it('should be a function', () => {
-    expect(uiExtractor).to.be.a.function;
+    expect(uiExtractor).to.be.a('function');
   })
 
   it('should return an object-typed instance of Node named "Controllers"', () => {

--- a/test/seeduxLookUpTests.js
+++ b/test/seeduxLookUpTests.js
@@ -1,70 +1,69 @@
 const chai = require('chai');
 const expect = require('chai').expect;
 const { testActionCreators, testReducers, testUI, testUIResources, testActionTypes1, testActionTypes2, answerActionCreators, answerReducers, answerUI } = require('./fixtures/seeduxLookUpFixtures');
-// const { addReducersToLookUpTable, addActionCreatorsToLookUpTable, addUIToLookUpTable, resetLookUpTable } = require('./../lib/seedux/src/seeduxLookUp');
-const lookUpUtils = require('./../lib/seedux/src/seeduxLookUp');
+const { addReducersToTable, addActionCreatorsToTable, addUIToTable, resetTable } = require('./../lib/seedux/src/seeduxLookUp');
 
-describe('addReducersToLookUpTable', () => {
+describe('addReducersToTable', () => {
 
 afterEach(() => {
-  resetLookUpTable();
+  resetTable();
 });
 
   it('should be a function', () => {
-    expect(lookUpUtils.addReducersToLookUpTable).to.be.a('function');
+    expect(addReducersToTable).to.be.a('function');
   })
 
-  it('should return a d3LookUpTable object', () => {
-    const reducersOutput = lookUpUtils.addReducersToLookUpTable(testReducers, testActionTypes1);
+  it('should return a d3Table object', () => {
+    const reducersOutput = addReducersToTable(testReducers, testActionTypes1);
     expect(reducersOutput).to.be.an('object');
   })
 
-  it('should return a properly structured d3LookUpTable', () => {
-    const reducersOutput = lookUpUtils.addReducersToLookUpTable(testReducers, testActionTypes1);
+  it('should return a properly structured d3Table', () => {
+    const reducersOutput = addReducersToTable(testReducers, testActionTypes1);
     expect(reducersOutput).to.deep.equal(answerReducers);
   })
 
 });
 
-describe('addActionCreatorsToLookUpTable', () => {
+describe('addActionCreatorsToTable', () => {
 
 afterEach(() => {
-  resetLookUpTable();
+  resetTable();
 });
 
   it('should be a function', () => {
-    expect(lookUpUtils.addActionCreatorsToLookUpTable).to.be.a('function');
+    expect(addActionCreatorsToTable).to.be.a('function');
   })
 
-  it('should return a d3LookUpTable object', () => {
-    const actionCreatorsOutput = lookUpUtils.addActionCreatorsToLookUpTable(testActionCreators, testActionTypes2);
+  it('should return a d3Table object', () => {
+    const actionCreatorsOutput = addActionCreatorsToTable(testActionCreators, testActionTypes2);
     expect(actionCreatorsOutput).to.be.an('object');
   })
 
-  it('should return a properly structured d3LookUpTable', () => {
-    const actionCreatorsOutput = lookUpUtils.addActionCreatorsToLookUpTable(testActionCreators, testActionTypes2);
+  it('should return a properly structured d3Table', () => {
+    const actionCreatorsOutput = addActionCreatorsToTable(testActionCreators, testActionTypes2);
     expect(actionCreatorsOutput).to.deep.equal(answerActionCreators);
   })
 
 });
 
-describe('addUIToLookUpTable', () => {
+describe('addUIToTable', () => {
 
 afterEach(() => {
-  resetLookUpTable();
+  resetTable();
 });
 
   it('should be a function', () => {
-    expect(lookUpUtils.addUIToLookUpTable).to.be.a('function');
+    expect(addUIToTable).to.be.a('function');
   })
 
-  it('should return a d3LookUpTable object', () => {
-    const uiOutput = lookUpUtils.addUIToLookUpTable(testUI, testUIResources);
+  it('should return a d3Table object', () => {
+    const uiOutput = addUIToTable(testUI, testUIResources);
     expect(uiOutput).to.be.an('object');
   })
 
-  it('should return a properly structured d3LookUpTable', () => {
-    const uiOutput = lookUpUtils.addUIToLookUpTable(testUI, testUIResources);
+  it('should return a properly structured d3Table', () => {
+    const uiOutput = addUIToTable(testUI, testUIResources);
     expect(uiOutput).to.deep.equal(answerUI);
   })
 

--- a/test/seeduxLookUpTests.js
+++ b/test/seeduxLookUpTests.js
@@ -1,6 +1,6 @@
 const chai = require('chai');
 const expect = require('chai').expect;
-const { testActionCreators, testReducers, testUI, testUIResources, testActionTypes1, testActionTypes2, answerActionCreators, answerReducers, answerUI } = require('./fixtures/seeduxLookUpFixtures');
+const { testActionCreators, testReducers, testUI, testUIResources, testActionMap, testActionTypes1, testActionTypes2, answerActionCreators, answerReducers, answerUI } = require('./fixtures/seeduxLookUpFixtures');
 const { addReducersToTable, addActionCreatorsToTable, addUIToTable, resetTable } = require('./../lib/seedux/src/seeduxLookUp');
 
 describe('addReducersToTable', () => {
@@ -58,12 +58,12 @@ afterEach(() => {
   })
 
   it('should return a d3Table object', () => {
-    const uiOutput = addUIToTable(testUI, testUIResources);
+    const uiOutput = addUIToTable(testUI, testUIResources, testActionMap);
     expect(uiOutput).to.be.an('object');
   })
 
   it('should return a properly structured d3Table', () => {
-    const uiOutput = addUIToTable(testUI, testUIResources);
+    const uiOutput = addUIToTable(testUI, testUIResources, testActionMap);
     expect(uiOutput).to.deep.equal(answerUI);
   })
 

--- a/test/seeduxLookUpTests.js
+++ b/test/seeduxLookUpTests.js
@@ -1,29 +1,29 @@
 const chai = require('chai');
 const expect = require('chai').expect;
-const { testActionCreators, testReducers, testUI, testUIResources, testActionMap, testActionTypes1, testActionTypes2, answerActionCreators, answerReducers, answerUI } = require('./fixtures/seeduxLookUpFixtures');
+const { testActionCreators, testReducers, testUI, testUIResources, testActionMap, testActionTypes1, testActionTypes2, answerActionCreators, answerReducers, answerUI, answerTable, testCodeObj } = require('./fixtures/seeduxLookUpFixtures');
 const { populateTable, addReducersToTable, addActionCreatorsToTable, addUIToTable, resetTable } = require('./../lib/seedux/src/seeduxLookUp');
 
-// describe('populateTable', () => {
+describe('populateTable', () => {
 
-// afterEach(() => {
-//   resetTable();
-// });
+afterEach(() => {
+  resetTable();
+});
 
-//   it('should be a function', () => {
-//     expect(populateTable).to.be.a('function');
-//   })
+  it('should be a function', () => {
+    expect(populateTable).to.be.a('function');
+  })
 
-//   it('should return a d3Table object', () => {
-//     const populateTableOutput = populateTable(testCodeObj);
-//     expect(populateTableOutput).to.be.an('object');
-//   })
+  it('should return a d3Table object', () => {
+    const populateTableOutput = populateTable(testCodeObj);
+    expect(populateTableOutput).to.be.an('object');
+  })
 
-//   it('should return a properly structured d3Table', () => {
-//     const populateTableOutput = populateTable(testCodeObj);
-//     expect(populateTableOutput).to.deep.equal(answerTable);
-//   })
+  it('should return a properly structured d3Table', () => {
+    const populateTableOutput = populateTable(testCodeObj);
+    expect(populateTableOutput).to.deep.equal(answerTable);
+  })
 
-// });
+});
 
 describe('addReducersToTable', () => {
 

--- a/test/seeduxLookUpTests.js
+++ b/test/seeduxLookUpTests.js
@@ -1,7 +1,29 @@
 const chai = require('chai');
 const expect = require('chai').expect;
 const { testActionCreators, testReducers, testUI, testUIResources, testActionMap, testActionTypes1, testActionTypes2, answerActionCreators, answerReducers, answerUI } = require('./fixtures/seeduxLookUpFixtures');
-const { addReducersToTable, addActionCreatorsToTable, addUIToTable, resetTable } = require('./../lib/seedux/src/seeduxLookUp');
+const { populateTable, addReducersToTable, addActionCreatorsToTable, addUIToTable, resetTable } = require('./../lib/seedux/src/seeduxLookUp');
+
+// describe('populateTable', () => {
+
+// afterEach(() => {
+//   resetTable();
+// });
+
+//   it('should be a function', () => {
+//     expect(populateTable).to.be.a('function');
+//   })
+
+//   it('should return a d3Table object', () => {
+//     const populateTableOutput = populateTable(testCodeObj);
+//     expect(populateTableOutput).to.be.an('object');
+//   })
+
+//   it('should return a properly structured d3Table', () => {
+//     const populateTableOutput = populateTable(testCodeObj);
+//     expect(populateTableOutput).to.deep.equal(answerTable);
+//   })
+
+// });
 
 describe('addReducersToTable', () => {
 

--- a/test/seeduxLookUpTests.js
+++ b/test/seeduxLookUpTests.js
@@ -1,0 +1,71 @@
+const chai = require('chai');
+const expect = require('chai').expect;
+const { testActionCreators, testReducers, testUI, testUIResources, testActionTypes1, testActionTypes2, answerActionCreators, answerReducers, answerUI } = require('./fixtures/seeduxLookUpFixtures');
+// const { addReducersToLookUpTable, addActionCreatorsToLookUpTable, addUIToLookUpTable, resetLookUpTable } = require('./../lib/seedux/src/seeduxLookUp');
+const lookUpUtils = require('./../lib/seedux/src/seeduxLookUp');
+
+describe('addReducersToLookUpTable', () => {
+
+afterEach(() => {
+  resetLookUpTable();
+});
+
+  it('should be a function', () => {
+    expect(lookUpUtils.addReducersToLookUpTable).to.be.a('function');
+  })
+
+  it('should return a d3LookUpTable object', () => {
+    const reducersOutput = lookUpUtils.addReducersToLookUpTable(testReducers, testActionTypes1);
+    expect(reducersOutput).to.be.an('object');
+  })
+
+  it('should return a properly structured d3LookUpTable', () => {
+    const reducersOutput = lookUpUtils.addReducersToLookUpTable(testReducers, testActionTypes1);
+    expect(reducersOutput).to.deep.equal(answerReducers);
+  })
+
+});
+
+describe('addActionCreatorsToLookUpTable', () => {
+
+afterEach(() => {
+  resetLookUpTable();
+});
+
+  it('should be a function', () => {
+    expect(lookUpUtils.addActionCreatorsToLookUpTable).to.be.a('function');
+  })
+
+  it('should return a d3LookUpTable object', () => {
+    const actionCreatorsOutput = lookUpUtils.addActionCreatorsToLookUpTable(testActionCreators, testActionTypes2);
+    expect(actionCreatorsOutput).to.be.an('object');
+  })
+
+  it('should return a properly structured d3LookUpTable', () => {
+    const actionCreatorsOutput = lookUpUtils.addActionCreatorsToLookUpTable(testActionCreators, testActionTypes2);
+    expect(actionCreatorsOutput).to.deep.equal(answerActionCreators);
+  })
+
+});
+
+describe('addUIToLookUpTable', () => {
+
+afterEach(() => {
+  resetLookUpTable();
+});
+
+  it('should be a function', () => {
+    expect(lookUpUtils.addUIToLookUpTable).to.be.a('function');
+  })
+
+  it('should return a d3LookUpTable object', () => {
+    const uiOutput = lookUpUtils.addUIToLookUpTable(testUI, testUIResources);
+    expect(uiOutput).to.be.an('object');
+  })
+
+  it('should return a properly structured d3LookUpTable', () => {
+    const uiOutput = lookUpUtils.addUIToLookUpTable(testUI, testUIResources);
+    expect(uiOutput).to.deep.equal(answerUI);
+  })
+
+});

--- a/test/seeduxReducersExtractorTests.js
+++ b/test/seeduxReducersExtractorTests.js
@@ -1,7 +1,9 @@
 const chai = require('chai');
 const expect = require('chai').expect;
 const { testReducers, testReducers2, testReducers3, testReducers4, testReducers5, testReducers6, answerReducers, answerReducers2, answerReducers3, answerReducers4, answerReducers5, answerReducers6 } = require('./fixtures/seeduxReducerExtractorFixtures');
-const { reducersExtractor, Node } = require('./../lib/seedux/src/seeduxExtractor');
+const { reducersExtractor } = require('./../lib/seedux/src/seeduxExtractor');
+// const { Node } = require('./../lib/seedux/src/seeduxAssembler');
+const assemblerUtils = require('./../lib/seedux/src/seeduxAssembler');
 const output = reducersExtractor(testReducers);
 const output2 = reducersExtractor(testReducers2);
 const output3 = reducersExtractor(testReducers3);
@@ -12,12 +14,12 @@ const output6 = reducersExtractor(testReducers6);
 describe('reducersExtractor', () => {
 
   it('should be a function', () => {
-    expect(reducersExtractor).to.be.a.function;
+    expect(reducersExtractor).to.be.a('function');
   })
 
   it('should return an object-typed instance of Node named "Reducers"', () => {
     expect(output).to.be.an('object');
-    expect(output.constructor).to.deep.equal(Node);
+    expect(output.constructor).to.deep.equal(assemblerUtils.Node);
     expect(output.name).to.deep.equal('Reducers');
   })
 
@@ -53,13 +55,13 @@ describe('"Reducers" node', () => {
   it('should have an array-typed property named children composed of object-typed Node(s)', () => {
     expect(output.children).to.be.an('array');
     expect(output.children[0]).to.be.an('object');
-    expect(output.children[0].constructor).to.deep.equal(Node);
+    expect(output.children[0].constructor).to.deep.equal(assemblerUtils.Node);
   })
 
   it('should have child nodes that each possess an array-typed property named children composed of object-typed Node(s)', () => {
     expect(output.children[0].children).to.be.an('array');
     expect(output.children[0].children[0]).to.be.an('object');
-    expect(output.children[0].children[0].constructor).to.deep.equal(Node);
+    expect(output.children[0].children[0].constructor).to.deep.equal(assemblerUtils.Node);
   })
 
 });

--- a/test/seeduxUIExtractorTests.js
+++ b/test/seeduxUIExtractorTests.js
@@ -1,6 +1,6 @@
 const chai = require('chai');
 const expect = require('chai').expect;
-const { webpackTestUI1, webpackTestUI2, webpackTestUI3, webpackTestUI4, browserifyTestUI1,  WebpackTestTodoList1, WebpackTestTodoList2, BrowserifyTestTodoList1, answerUI1, answerUI2, answerUI3, answerUI4, answerUI5 } = require('./fixtures/seeduxUIExtractorFixtures');
+const { webpackTestUI1, webpackTestUI2, webpackTestUI3, webpackTestUI4, webpackTestUI5, browserifyTestUI1,  WebpackTestTodoList1, WebpackTestTodoList2, BrowserifyTestTodoList1, answerUI1, answerUI2, answerUI3, answerUI4, answerUI5, answerUI6 } = require('./fixtures/seeduxUIExtractorFixtures');
 const { uiExtractor } = require('./../lib/seedux/src/seeduxExtractor');
 const { Node, resetUIHeadNode } = require('./../lib/seedux/src/seeduxAssembler');
 
@@ -41,9 +41,14 @@ afterEach(() => {
     expect(webpackTestOutput4).to.deep.equal(answerUI4);
   })
 
+  it('should return a properly structured D3 hierarchical tree output for another given webpack-bundled input with mapStateToProps and mapDispatchToProps passed as arguments', () => {
+    const webpackTestOutput5 = uiExtractor(webpackTestUI5);
+    expect(webpackTestOutput5).to.deep.equal(answerUI5)
+  })
+
   it('should return a properly structured D3 hierarchical tree output for a given browserify-bundled input with mapStateToProps and mapDispatchToProps passed as arguments', () => {
     const browserifyTestOutput1 = uiExtractor(browserifyTestUI1);
-    expect(browserifyTestOutput1).to.deep.equal(answerUI5);
+    expect(browserifyTestOutput1).to.deep.equal(answerUI6);
   })
   
 

--- a/test/seeduxUIExtractorTests.js
+++ b/test/seeduxUIExtractorTests.js
@@ -2,14 +2,12 @@ const chai = require('chai');
 const expect = require('chai').expect;
 const { webpackTestUI1, webpackTestUI2, webpackTestUI3, webpackTestUI4, browserifyTestUI1,  WebpackTestTodoList1, WebpackTestTodoList2, BrowserifyTestTodoList1, answerUI1, answerUI2, answerUI3, answerUI4, answerUI5 } = require('./fixtures/seeduxUIExtractorFixtures');
 const { uiExtractor } = require('./../lib/seedux/src/seeduxExtractor');
-// const { Node } = require('./../lib/seedux/src/seeduxAssembler');
-const assemblerUtils = require('./../lib/seedux/src/seeduxAssembler');
-const { resetUIHeadNode } = require('./../lib/seedux/src/seeduxLookUp');
+const { Node, resetUIHeadNode } = require('./../lib/seedux/src/seeduxAssembler');
 
 describe('uiExtractor (React)', () => {
 
 afterEach(() => {
-  assemblerUtils.resetUIHeadNode();
+  resetUIHeadNode();
 });
 
   it('should be a function', () => {
@@ -54,21 +52,21 @@ afterEach(() => {
 describe('"Containers" node', () => {
 
 afterEach(() => {
-  assemblerUtils.resetUIHeadNode();
+  resetUIHeadNode();
 })
 
   it('should have an array-typed property named children composed of object-typed Node(s)', () => {
     const webpackTestOutput1 = uiExtractor(webpackTestUI1);
     expect(webpackTestOutput1.children).to.be.an('array');
     expect(webpackTestOutput1.children[0]).to.be.an('object');
-    expect(webpackTestOutput1.children[0].constructor).to.deep.equal(assemblerUtils.Node);
+    expect(webpackTestOutput1.children[0].constructor).to.deep.equal(Node);
   })
 
   it('should have child nodes that each possess an array-typed property named children composed of object-typed Node(s)', () => {
     const webpackTestOutput1 = uiExtractor(webpackTestUI1);
     expect(webpackTestOutput1.children[0].children).to.be.an('array');
     expect(webpackTestOutput1.children[0].children[0]).to.be.an('object');
-    expect(webpackTestOutput1.children[0].children[0].constructor).to.deep.equal(assemblerUtils.Node);
+    expect(webpackTestOutput1.children[0].children[0].constructor).to.deep.equal(Node);
   })
 
 });

--- a/test/seeduxUIExtractorTests.js
+++ b/test/seeduxUIExtractorTests.js
@@ -1,16 +1,19 @@
 const chai = require('chai');
 const expect = require('chai').expect;
 const { webpackTestUI1, webpackTestUI2, webpackTestUI3, webpackTestUI4, browserifyTestUI1,  WebpackTestTodoList1, WebpackTestTodoList2, BrowserifyTestTodoList1, answerUI1, answerUI2, answerUI3, answerUI4, answerUI5 } = require('./fixtures/seeduxUIExtractorFixtures');
-const { uiExtractor, Node, resetUIHeadNode } = require('./../lib/seedux/src/seeduxExtractor');
+const { uiExtractor } = require('./../lib/seedux/src/seeduxExtractor');
+// const { Node } = require('./../lib/seedux/src/seeduxAssembler');
+const assemblerUtils = require('./../lib/seedux/src/seeduxAssembler');
+const { resetUIHeadNode } = require('./../lib/seedux/src/seeduxLookUp');
 
 describe('uiExtractor (React)', () => {
 
 afterEach(() => {
-  resetUIHeadNode();
+  assemblerUtils.resetUIHeadNode();
 });
 
   it('should be a function', () => {
-    expect(uiExtractor).to.be.a.function;
+    expect(uiExtractor).to.be.a('function');
   })
 
   it('should return an object-typed instance of Node named "Containers"', () => {
@@ -18,7 +21,6 @@ afterEach(() => {
     expect(webpackTestOutput1).to.be.an('object');
     expect(webpackTestOutput1.constructor).to.deep.equal(Node);
     expect(webpackTestOutput1.name).to.deep.equal('Containers');
-    resetUIHeadNode();
   })
 
   it('should return a properly structured D3 hierarchical tree output for a given webpack-bundled input with mapStateToProps and mapDispatchToProps passed as arguments', () => {
@@ -52,21 +54,21 @@ afterEach(() => {
 describe('"Containers" node', () => {
 
 afterEach(() => {
-  resetUIHeadNode();
+  assemblerUtils.resetUIHeadNode();
 })
 
   it('should have an array-typed property named children composed of object-typed Node(s)', () => {
     const webpackTestOutput1 = uiExtractor(webpackTestUI1);
     expect(webpackTestOutput1.children).to.be.an('array');
     expect(webpackTestOutput1.children[0]).to.be.an('object');
-    expect(webpackTestOutput1.children[0].constructor).to.deep.equal(Node);
+    expect(webpackTestOutput1.children[0].constructor).to.deep.equal(assemblerUtils.Node);
   })
 
   it('should have child nodes that each possess an array-typed property named children composed of object-typed Node(s)', () => {
     const webpackTestOutput1 = uiExtractor(webpackTestUI1);
     expect(webpackTestOutput1.children[0].children).to.be.an('array');
     expect(webpackTestOutput1.children[0].children[0]).to.be.an('object');
-    expect(webpackTestOutput1.children[0].children[0].constructor).to.deep.equal(Node);
+    expect(webpackTestOutput1.children[0].children[0].constructor).to.deep.equal(assemblerUtils.Node);
   })
 
 });


### PR DESCRIPTION
COMPLETED:
- D3Table enables linear time determination of node illumination upon re-render
- Containers' children consist of props returned by mapStateToProps and/or mapDispatchToProps

NEXT STEPS:
- Ensure look-up table illuminates props that have been wrapped with dispatch by mapDispatchToProps