### PR TITLE
Node illumination supports props returned by mapDispatchToProps

### DIFF
--- a/lib/seedux/src/seeduxAssembler.js
+++ b/lib/seedux/src/seeduxAssembler.js
@@ -11,15 +11,19 @@ function Node(name) {
   this.name = name;
 }
 
-function assembleUINodes(uiName, uiPropNames = [], uiMapState = []) {
+function assembleUINodes(uiName, uiPropNames = [], uiMapState = [], uiMapDispatch = []) {
   const uiNameNode = new Node(uiName);
   if (uiPropNames) {
     uiNameNode.children = [];
-    uiPropNames.forEach(p => uiNameNode.children.push(new Node(p)));
+    uiPropNames.forEach(p => { 
+      if (!/[^\w]/gi.test(p)) {
+        uiNameNode.children.push(new Node(p));
+      }
+    })
   }
   uiHeadNode.children.push(uiNameNode);
   parsedCodeObj.ui = uiHeadNode;
-  parsedCodeObj.uiResources[uiName] = uiMapState[uiName];
+  parsedCodeObj.uiResources[uiName] = Object.assign({}, uiMapState[uiName], uiMapDispatch[uiName])
   return uiHeadNode;
 };
 
@@ -38,7 +42,9 @@ function assembleReducerNodes(reducers, reducerNames, reducerCases = []) {
       if (reducerCases[i]) {
           reducerCases.forEach(c => {
             if (reducers[name].includes(c)) {
-              reducerNode.children.push(new Node(c));
+              if (!/[^\w]/gi.test(c)) {
+                reducerNode.children.push(new Node(c));
+              }
             }
           });
       }

--- a/lib/seedux/src/seeduxExtractor.js
+++ b/lib/seedux/src/seeduxExtractor.js
@@ -45,10 +45,8 @@ function uiExtractor(ui) {
       const splitPropNames = uiPropNames.split('|');
       mapStateToPropsDef = uiStateKeys = splitPropNames[0];
       mapDispatchToPropsDef = uiActionCreators = splitPropNames[1];
-      mapStateToPropsSplitAtKeys = mapStateToPropsDef.split(','); // || mapStateToPropsDef;
-      console.log('mapDispatchToPropsDef', mapDispatchToPropsDef)
-      mapDispatchToPropsSplitAtKeys = mapDispatchToPropsDef.split(','); // || mapDispatchToPropsDef;
-      console.log('mapDispatchToPropsSplitAtKeys', mapDispatchToPropsSplitAtKeys)
+      //mapStateToPropsSplitAtKeys = mapStateToPropsDef.split(','); // || mapStateToPropsDef;
+      //mapDispatchToPropsSplitAtKeys = mapDispatchToPropsDef.split(','); // || mapDispatchToPropsDef;
       if (mapStateToPropsDef.includes('state.')) {
         uiStateKeys = uiStateKeys.split('state.').slice(1).map(subStr => subStr = subStr.slice(0, subStr.lastIndexOf('.'))).map(subStr => subStr.replace(/[^\w.]/gi, ''));
       }
@@ -76,9 +74,7 @@ function uiExtractor(ui) {
             uiMapDispatch[uiName][prop].push(ac);
           })
         })
-        console.log('uiMapDispatch', uiMapDispatch)
-      
-    }
+      }
     uiPropNames = uiPropNames.split(':').map(subStr => subStr = subStr.slice(-1 * ((subStr.length - 1) - subStr.lastIndexOf(' ')))).filter(subStr => /[\w*]/gi.test(subStr));
   }
 

--- a/lib/seedux/src/seeduxExtractor.js
+++ b/lib/seedux/src/seeduxExtractor.js
@@ -22,7 +22,9 @@ function uiExtractor(ui) {
   let uiPropNames = ui[uiName];
   let mapStateToPropsDef, mapStateToPropsSplitAtKeys, mapDispatchToPropsDef, mapDispatchToPropsSplitAtKeys, uiStateKeys, uiStatePropNames, uiDispatchPropNames, uiActionCreators;
   let uiMapState = {};
+  let uiMapDispatch = {};
   uiMapState[uiName] = {};
+  uiMapDispatch[uiName] = {};
 
   if (uiPropNames.includes(defaultMapStateToProps) && uiPropNames.includes(defaultMapDispatchToProps)) {
     uiPropNames = false;
@@ -44,7 +46,9 @@ function uiExtractor(ui) {
       mapStateToPropsDef = uiStateKeys = splitPropNames[0];
       mapDispatchToPropsDef = uiActionCreators = splitPropNames[1];
       mapStateToPropsSplitAtKeys = mapStateToPropsDef.split(','); // || mapStateToPropsDef;
+      console.log('mapDispatchToPropsDef', mapDispatchToPropsDef)
       mapDispatchToPropsSplitAtKeys = mapDispatchToPropsDef.split(','); // || mapDispatchToPropsDef;
+      console.log('mapDispatchToPropsSplitAtKeys', mapDispatchToPropsSplitAtKeys)
       if (mapStateToPropsDef.includes('state.')) {
         uiStateKeys = uiStateKeys.split('state.').slice(1).map(subStr => subStr = subStr.slice(0, subStr.lastIndexOf('.'))).map(subStr => subStr.replace(/[^\w.]/gi, ''));
       }
@@ -53,7 +57,7 @@ function uiExtractor(ui) {
       }
         uiStatePropNames = mapStateToPropsDef.split(':').map(subStr => subStr = subStr.slice(-1 * ((subStr.length - 1) - subStr.lastIndexOf(' ')))).filter(subStr => /[\w*]/gi.test(subStr));
         uiDispatchPropNames = mapDispatchToPropsDef.split(':').map(subStr => subStr = subStr.slice(-1 * ((subStr.length - 1) - subStr.lastIndexOf(' ')))).filter(subStr => /[\w*]/gi.test(subStr));
-        uiActionCreators = uiActionCreators.split('dispatch(').slice(1).map(subStr => subStr = subStr.slice(0, subStr.indexOf('(')));
+        uiActionCreators = uiActionCreators.split('dispatch(').slice(1).map(subStr => subStr = subStr.slice(subStr.indexOf('.') + 1, subStr.indexOf(')')));
 
         uiStatePropNames.forEach(prop => {
           uiMapState[uiName][prop] = [];
@@ -65,22 +69,20 @@ function uiExtractor(ui) {
             })
           })
         })
-        // uiDispatchPropNames.forEach(prop => {
-        //   uiMapState[uiName][prop] = [];
-        //   uiActionCreators.forEach(ac => {
-        //     mapDispatchToPropsSplitAtKeys.forEach(def => {
-        //       if (def.includes(ac) && def.includes(prop)) {
-        //         uiMapState[uiName][prop].push(ac);
-        //       }
-        //     })
-        //   })
-        // })
+
+        uiDispatchPropNames.forEach(prop => {
+          uiMapDispatch[uiName][prop] = [];
+          uiActionCreators.forEach(ac => {
+            uiMapDispatch[uiName][prop].push(ac);
+          })
+        })
+        console.log('uiMapDispatch', uiMapDispatch)
       
     }
     uiPropNames = uiPropNames.split(':').map(subStr => subStr = subStr.slice(-1 * ((subStr.length - 1) - subStr.lastIndexOf(' ')))).filter(subStr => /[\w*]/gi.test(subStr));
   }
 
-  return assembleUINodes(uiName, uiPropNames, uiMapState);
+  return assembleUINodes(uiName, uiPropNames, uiMapState, uiMapDispatch);
 };
 
 /**

--- a/seeduxChrome/src/app.jsx
+++ b/seeduxChrome/src/app.jsx
@@ -70,7 +70,6 @@ class App extends React.Component {
           future: response.future,
           d3Table: response.d3Table
         });
-        console.log('d3Table', d3Table)
     });
 
     // add a listener for new log Entries from the content script

--- a/seeduxChrome/src/app.jsx
+++ b/seeduxChrome/src/app.jsx
@@ -70,6 +70,7 @@ class App extends React.Component {
           future: response.future,
           d3Table: response.d3Table
         });
+        console.log('d3Table', d3Table)
     });
 
     // add a listener for new log Entries from the content script


### PR DESCRIPTION
COMPLETED:
- Node illumination supports props returned by mapDispatchToProps
- uiExtractor scrubs improperly parsed fields to ensure they do not populate the ui and reducer tree data structures